### PR TITLE
Fix expression resolving when specified in a profile

### DIFF
--- a/maven/src/main/java/org/commonjava/maven/galley/maven/model/view/MavenElementView.java
+++ b/maven/src/main/java/org/commonjava/maven/galley/maven/model/view/MavenElementView.java
@@ -230,7 +230,14 @@ public class MavenElementView
         //
 
         //        logger.info( "Resolving expressions in: '{}'", val );
-        return pomView.resolveExpressions( val );
+        if ( getProfileId() == null )
+        {
+            return pomView.resolveExpressions( val );
+        }
+        else
+        {
+            return pomView.resolveExpressions( val, getProfileId() );
+        }
     }
 
     protected Node getNode( final String path )

--- a/maven/src/main/java/org/commonjava/maven/galley/maven/model/view/MavenPomView.java
+++ b/maven/src/main/java/org/commonjava/maven/galley/maven/model/view/MavenPomView.java
@@ -94,6 +94,15 @@ public class MavenPomView
         }
 
         String value = resolveXPathExpression( expr, true, -1 );
+
+        for ( int i = 0; value == null && activeProfileIds != null && i < activeProfileIds.length; i++ )
+        {
+            final String profileId = activeProfileIds[i];
+            value =
+                resolveXPathExpression( "//profile[id/text()=\"" + profileId + "\"]/properties/" + expression, true,
+                                        -1, activeProfileIds );
+        }
+
         if ( value == null )
         {
             final List<Node> propertyNodes = resolveXPathToAggregatedNodeList( "/project/properties/*", true, -1 );
@@ -106,14 +115,6 @@ public class MavenPomView
                     break;
                 }
             }
-        }
-
-        for ( int i = 0; value == null && activeProfileIds != null && i < activeProfileIds.length; i++ )
-        {
-            final String profileId = activeProfileIds[i];
-            value =
-                resolveXPathExpression( "//profile[id/text()=\"" + profileId + "\"]/properties/" + expression, true,
-                                        -1, activeProfileIds );
         }
 
         return value;

--- a/maven/src/test/java/org/commonjava/maven/galley/maven/model/view/MavenPomViewTest.java
+++ b/maven/src/test/java/org/commonjava/maven/galley/maven/model/view/MavenPomViewTest.java
@@ -67,6 +67,24 @@ public class MavenPomViewTest
 
     }
 
+    /**
+     * Checks if plugin version specified as version property in a profile gets
+     * resolved correctly. There is also global version property with different
+     * value so it also checks if the profile value takes preference.
+     */
+    @Test
+    public void pluginWithVersionPropertyInProfile()
+        throws Exception
+    {
+        MavenPomView pomView = loadPoms( new String[] { "test" },
+                                         "pom-with-plugin-version-property-in-profile.xml" );
+
+        PluginView pv = pomView.getAllBuildPlugins()
+                               .get( 0 );
+
+        assertThat( pv.getVersion(), equalTo( "2.0" ) );
+    }
+
     @Test
     public void dependencyManagedBySingleBOM()
         throws Exception

--- a/maven/src/test/resources/view/pom/pom-with-plugin-version-property-in-profile.xml
+++ b/maven/src/test/resources/view/pom/pom-with-plugin-version-property-in-profile.xml
@@ -1,0 +1,30 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.foo</groupId>
+  <artifactId>bar</artifactId>
+  <version>1</version>
+
+  <properties>
+    <testPluginVersion>1.0</testPluginVersion>
+  </properties>      
+
+  <profiles>
+    <profile>
+      <id>test</id>
+
+      <properties>
+        <testPluginVersion>2.0</testPluginVersion>
+      </properties>      
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>dep.group</groupId>
+            <artifactId>dep-artifact</artifactId>
+            <version>${testPluginVersion}</version>
+          </plugin>>
+        </plugins>>
+      </build>>
+    </profile>
+  </profiles>
+
+</project>


### PR DESCRIPTION
by passing profile ID as active profile to resolveExpressions when not null.
Also move reading of properties from active profiles ahead of reading global
properties because the ones in a profile should take preference.
Adding a test to verify the problems.
