### PR TITLE
[Fixes #27] Make sure the short-circuited return in the batch retriever ...

### DIFF
--- a/core/src/main/java/org/commonjava/maven/galley/internal/xfer/BatchRetriever.java
+++ b/core/src/main/java/org/commonjava/maven/galley/internal/xfer/BatchRetriever.java
@@ -72,15 +72,16 @@ public final class BatchRetriever
     @Override
     public void run()
     {
-        if ( !hasMoreTries() )
-        {
-            return;
-        }
-
-        lastTry = resources.get( tries );
-        logger.debug( "Try #{}: {}", tries, lastTry );
         try
         {
+            if ( !hasMoreTries() )
+            {
+                return;
+            }
+
+            lastTry = resources.get( tries );
+            logger.debug( "Try #{}: {}", tries, lastTry );
+
             transfer = xfer.retrieve( lastTry, suppressFailures );
         }
         catch ( final TransferException e )


### PR DESCRIPTION
...counts down the latch...in fact, make sure no matter what that latch counts down.