### PR TITLE
Fix problems with simultaneous downloads

### DIFF
--- a/core/src/main/java/org/commonjava/maven/galley/internal/xfer/DownloadHandler.java
+++ b/core/src/main/java/org/commonjava/maven/galley/internal/xfer/DownloadHandler.java
@@ -94,10 +94,14 @@ public class DownloadHandler
         //            return false;
         //        }
 
-        Transfer result = joinDownload( target, timeoutSeconds, suppressFailures );
-        if ( result == null )
+        Transfer result;
+        synchronized ( pending )
         {
-            result = startDownload( resource, target, timeoutSeconds, transport, suppressFailures );
+            result = joinDownload( target, timeoutSeconds, suppressFailures );
+            if ( result == null )
+            {
+                result = startDownload( resource, target, timeoutSeconds, transport, suppressFailures );
+            }
         }
 
         return result;


### PR DESCRIPTION
There was a problem when 2 urlmaps were requested in parallel. 2 downloads at
the same time caused that one of them failed. It was because both threads
determined that there is no pending download and then both started it. After
download both of them tried to save local proxy file. While one of them
succeeded, the second one failed because it could not create the directory
where it wanted to store the downloaded file. The reason was that the directory
already existed.

The proposed solution ensures that the check if a download is already enqueued and then add it in the queue if not is synchronized between thareads. I'm not sure if this is too brutal or not, but IMO the two calls joinDownload + startDownload are one unit and the critical variable in this is _pending_ map, which is checked in joinDownload and then optionally modified in startDownload.