### PR TITLE
Make getValue() in AbstractMavenElementView resilient to all kinds of…

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/util/TransferInputStream.java
+++ b/api/src/main/java/org/commonjava/maven/galley/util/TransferInputStream.java
@@ -1,0 +1,34 @@
+package org.commonjava.maven.galley.util;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.commonjava.maven.galley.event.FileAccessEvent;
+import org.commonjava.maven.galley.spi.event.FileEventManager;
+
+public class TransferInputStream
+    extends FilterInputStream
+{
+
+    private final FileAccessEvent event;
+
+    private final FileEventManager fileEventManager;
+
+    public TransferInputStream( final InputStream in, final FileAccessEvent event,
+                                final FileEventManager fileEventManager )
+    {
+        super( in );
+        this.event = event;
+        this.fileEventManager = fileEventManager;
+    }
+
+    @Override
+    public void close()
+        throws IOException
+    {
+        super.close();
+        fileEventManager.fire( event );
+    }
+
+}

--- a/api/src/main/java/org/commonjava/maven/galley/util/TransferOutputStream.java
+++ b/api/src/main/java/org/commonjava/maven/galley/util/TransferOutputStream.java
@@ -19,18 +19,35 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+import org.commonjava.maven.galley.event.FileStorageEvent;
 import org.commonjava.maven.galley.model.Transfer.TransferUnlocker;
+import org.commonjava.maven.galley.spi.event.FileEventManager;
 
-public class TransferUnlockingOutputStream
+public class TransferOutputStream
     extends FilterOutputStream
 {
 
     private final TransferUnlocker unlocker;
 
-    public TransferUnlockingOutputStream( final OutputStream out, final TransferUnlocker unlocker )
+    private final FileEventManager fileEventManager;
+
+    private final FileStorageEvent event;
+
+    public TransferOutputStream( final OutputStream out, final TransferUnlocker unlocker, final FileStorageEvent event,
+                                 final FileEventManager fileEventManager )
     {
         super( out );
         this.unlocker = unlocker;
+        this.event = event;
+        this.fileEventManager = fileEventManager;
+    }
+
+    public TransferOutputStream( final OutputStream out, final TransferUnlocker unlocker )
+    {
+        super( out );
+        this.unlocker = unlocker;
+        this.event = null;
+        this.fileEventManager = null;
     }
 
     @Override
@@ -39,6 +56,11 @@ public class TransferUnlockingOutputStream
     {
         super.close();
         unlocker.unlock();
+
+        if ( fileEventManager != null )
+        {
+            fileEventManager.fire( event );
+        }
     }
 
 }

--- a/caches/partyline/src/main/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProvider.java
+++ b/caches/partyline/src/main/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProvider.java
@@ -42,8 +42,6 @@ import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.maven.galley.spi.event.FileEventManager;
 import org.commonjava.maven.galley.spi.io.PathGenerator;
 import org.commonjava.maven.galley.spi.io.TransferDecorator;
-import org.commonjava.maven.galley.util.AtomicFileOutputStreamWrapper;
-import org.commonjava.maven.galley.util.AtomicFileOutputStreamWrapper.AtomicStreamCallbacks;
 import org.commonjava.maven.galley.util.PathUtils;
 import org.commonjava.util.partyline.JoinableFileManager;
 import org.slf4j.Logger;
@@ -215,23 +213,27 @@ public class PartyLineCacheProvider
             throw new IOException( "Cannot create directory: " + dir );
         }
 
-        final File downloadFile = new File( targetFile.getPath() + CacheProvider.SUFFIX_TO_WRITE );
-        final OutputStream stream = fileManager.openOutputStream( downloadFile );
+        return fileManager.openOutputStream( targetFile );
 
-        return new AtomicFileOutputStreamWrapper( targetFile, downloadFile, stream, new AtomicStreamCallbacks()
-        {
-            @Override
-            public void beforeClose()
-            {
-                fileManager.lock( targetFile );
-            }
+        //        fileManager.lock( targetFile );
 
-            @Override
-            public void afterClose()
-            {
-                fileManager.unlock( targetFile );
-            }
-        } );
+        //        final File downloadFile = new File( targetFile.getPath() + CacheProvider.SUFFIX_TO_WRITE );
+        //        final OutputStream stream = fileManager.openOutputStream( downloadFile );
+        //
+        //        return new AtomicFileOutputStreamWrapper( targetFile, downloadFile, stream, new AtomicStreamCallbacks()
+        //        {
+        //            @Override
+        //            public void beforeClose()
+        //            {
+        //                //                fileManager.lock( targetFile );
+        //            }
+        //
+        //            @Override
+        //            public void afterClose()
+        //            {
+        //                fileManager.unlock( targetFile );
+        //            }
+        //        } );
     }
 
     @Override

--- a/core/src/main/java/org/commonjava/maven/galley/internal/xfer/DownloadHandler.java
+++ b/core/src/main/java/org/commonjava/maven/galley/internal/xfer/DownloadHandler.java
@@ -63,8 +63,8 @@ public class DownloadHandler
 
     // FIXME: download batch
 
-    public Transfer download( final ConcreteResource resource, final Transfer target, final int timeoutSeconds, final Transport transport,
-                              final boolean suppressFailures )
+    public Transfer download( final ConcreteResource resource, final Transfer target, final int timeoutSeconds,
+                              final Transport transport, final boolean suppressFailures )
         throws TransferException
     {
         if ( !resource.allowsDownloading() )
@@ -154,8 +154,8 @@ public class DownloadHandler
         return null;
     }
 
-    private Transfer startDownload( final ConcreteResource resource, final Transfer target, final int timeoutSeconds, final Transport transport,
-                                    final boolean suppressFailures )
+    private Transfer startDownload( final ConcreteResource resource, final Transfer target, final int timeoutSeconds,
+                                    final Transport transport, final boolean suppressFailures )
         throws TransferException
     {
         if ( target.exists() )
@@ -178,8 +178,9 @@ public class DownloadHandler
 
             if ( job.getError() != null )
             {
-                logger.debug( "NFC: Download error. Marking as missing: {}\nError was: {}", job.getError(), resource, job.getError()
-                                                                                                                         .getMessage() );
+                logger.debug( "NFC: Download error. Marking as missing: {}\nError was: {}", job.getError(), resource,
+                              job.getError()
+                                 .getMessage() );
                 nfc.addMissing( resource );
 
                 if ( !suppressFailures )

--- a/maven/src/main/java/org/commonjava/maven/galley/maven/model/view/AbstractMavenElementView.java
+++ b/maven/src/main/java/org/commonjava/maven/galley/maven/model/view/AbstractMavenElementView.java
@@ -55,14 +55,13 @@ public abstract class AbstractMavenElementView<T extends MavenXmlView<?>>
 
     protected String getValue( final String path )
     {
-        final Element e = (Element) xmlView.resolveXPathToNodeFrom( elementContext, path, false );
-
-        if ( e == null )
+        final Node node = xmlView.resolveXPathToNodeFrom( elementContext, path, false );
+        if ( node == null )
         {
             return null;
         }
 
-        return e.getTextContent()
+        return node.getTextContent()
                 .trim();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
   <properties>
     <projectOwner>Red Hat, Inc.</projectOwner>
     <atlasVersion>0.14.0</atlasVersion>
-    <partylineVersion>1.3</partylineVersion>
+    <partylineVersion>1.4-SNAPSHOT</partylineVersion>
   </properties>
 
   <dependencyManagement>

--- a/transports/filearc/src/main/java/org/commonjava/maven/galley/filearc/internal/FileDownload.java
+++ b/transports/filearc/src/main/java/org/commonjava/maven/galley/filearc/internal/FileDownload.java
@@ -60,7 +60,7 @@ public class FileDownload
             if ( src.exists() && !src.isDirectory() )
             {
                 in = new FileInputStream( src );
-                out = txfr.openOutputStream( TransferOperation.DOWNLOAD, false );
+                out = txfr.openOutputStream( TransferOperation.DOWNLOAD );
                 copy( in, out );
             }
 

--- a/transports/filearc/src/main/java/org/commonjava/maven/galley/filearc/internal/ZipDownload.java
+++ b/transports/filearc/src/main/java/org/commonjava/maven/galley/filearc/internal/ZipDownload.java
@@ -84,7 +84,7 @@ public class ZipDownload
                 else
                 {
                     in = zf.getInputStream( entry );
-                    out = txfr.openOutputStream( TransferOperation.DOWNLOAD, false );
+                    out = txfr.openOutputStream( TransferOperation.DOWNLOAD );
 
                     copy( in, out );
 

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
@@ -110,9 +110,11 @@ public final class HttpDownload
                 final HttpEntity entity = response.getEntity();
 
                 in = entity.getContent();
-                out = target.openOutputStream( TransferOperation.DOWNLOAD, false );
+                out = target.openOutputStream( TransferOperation.DOWNLOAD );
                 copy( in, out );
+                logger.info( "Ensuring all HTTP data is consumed..." );
                 EntityUtils.consume( entity );
+                logger.info( "All HTTP data was consumed." );
             }
             catch ( final IOException e )
             {
@@ -123,6 +125,8 @@ public final class HttpDownload
             finally
             {
                 closeQuietly( in );
+
+                logger.info( "Closing output stream: {}", out );
                 closeQuietly( out );
             }
         }


### PR DESCRIPTION
… Nodes, and do away with temp-file downloading...use file locking with joinable streams instead. Make all download implementations fire FileStorageEvent. Upgrade to partyline 1.4-SNAPSHOT to get non-blocking outputStream close() and better use of callbacks/file-locking for joinable streams. Make access and storage events fire after the access or storage activity completes...maybe not as efficient as it could be...