### PR TITLE
Change return type in ConcreteResource methods

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/model/ConcreteResource.java
+++ b/api/src/main/java/org/commonjava/maven/galley/model/ConcreteResource.java
@@ -163,7 +163,7 @@ public class ConcreteResource
         return path == ROOT || ROOT.equals( path );
     }
 
-    public Resource getParent()
+    public ConcreteResource getParent()
     {
         if ( isRoot() )
         {
@@ -173,7 +173,7 @@ public class ConcreteResource
         return new ConcreteResource( location, parentPath( path ) );
     }
 
-    public Resource getChild( final String file )
+    public ConcreteResource getChild( final String file )
     {
         return new ConcreteResource( location, normalize( path, file ) );
     }

--- a/api/src/main/java/org/commonjava/maven/galley/model/Transfer.java
+++ b/api/src/main/java/org/commonjava/maven/galley/model/Transfer.java
@@ -102,12 +102,12 @@ public class Transfer
             return this;
         }
 
-        return provider.getTransfer( (ConcreteResource) resource.getParent() );
+        return provider.getTransfer( resource.getParent() );
     }
 
     public Transfer getChild( final String file )
     {
-        return provider.getTransfer( (ConcreteResource) resource.getChild( file ) );
+        return provider.getTransfer( resource.getChild( file ) );
     }
 
     public void touch()


### PR DESCRIPTION
It does not make much sense to return Resource if we don'ŧ target an API
shared by multiple classes while casting it to ConcreteResource in
calling methods. So I think it is better to specify as concrete return
class as possible in this case.