### PR TITLE
Fix SpecialPathConstants to avoid multi-level metadata again

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/io/SpecialPathConstants.java
+++ b/api/src/main/java/org/commonjava/maven/galley/io/SpecialPathConstants.java
@@ -18,7 +18,7 @@ public class SpecialPathConstants
     static{
         Map<SpecialPathMatcher, SpecialPathInfo> sp = new HashMap<SpecialPathMatcher, SpecialPathInfo>();
 
-        SpecialPathInfo pi = SpecialPathInfo.from( new FilePatternMatcher( ".*\\.http-metadata\\.json" ) )
+        SpecialPathInfo pi = SpecialPathInfo.from( new FilePatternMatcher( ".*\\.http-metadata\\.json$" ) )
                                             .setDecoratable( false )
                                             .setListable( false )
                                             .setPublishable( false )
@@ -39,7 +39,7 @@ public class SpecialPathConstants
 
         sp.put( pi.getMatcher(), pi );
 
-        for ( String extPattern: Arrays.asList( ".+\\.asc", ".+\\.md5", ".+\\.sha.*") )
+        for ( String extPattern: Arrays.asList( ".+\\.asc$", ".+\\.md5$", ".+\\.sha[\\d]+$") )
         {
             pi = SpecialPathInfo.from( new FilePatternMatcher( extPattern ) )
                                 .setDecoratable( false )


### PR DESCRIPTION
The checksum regex patterns were not specific enough. The checksums
metadata also matched the checksum pattern, so metadata got all the
properties of checksums (listable, publishable, retrievable, storable)
when they were checked against the checksum pattern first.

It led to creation of additional metadata levels with each listing and
in the end to "filename too long" exceptions.

Example of such filename found in Indy log:
/org/codehaus/woodstox/stax2-api/3.1.4/stax2-api-3.1.4.pom.sha1.http-metadata.json.asc.http-metadata.json.asc.http-metadata.json.md5.http-metadata.json.sha1.http-metadata.json.sha1.http-metadata.json.asc.http-metadata.json.md5.http-metadata.json.sha1.http-metadata.json.sha1.http-metadata.json.md5