### PR TITLE
Fix listing to not contain links not leading into subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .idea
 *.iml
 target/
+
+# eclipse
+.classpath
+.project
+.settings/


### PR DESCRIPTION
When there is a chain of multiple Indy instances, then the listing have
grown bigger by the links from the footer saying what were the source
locations for a group content. For example "builds-untested" or "http:/"
(this one is really weird).

The fix checks if the link points to the same server into a subdirectory
of the currently listed directory and includes only the links that do.