### PR TITLE
Implement NFS storage CacheProvider

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
+++ b/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
@@ -74,9 +74,11 @@ public interface CacheProvider
     void mkdirs( ConcreteResource resource )
         throws IOException;
 
+    @Deprecated
     void createFile( ConcreteResource resource )
         throws IOException;
 
+    @Deprecated
     void createAlias( ConcreteResource from, ConcreteResource to )
         throws IOException;
 

--- a/caches/infinispan/pom.xml
+++ b/caches/infinispan/pom.xml
@@ -43,12 +43,20 @@
       <artifactId>galley-cache-tck</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.commonjava.maven.galley</groupId>
+      <artifactId>galley-cache-partyline</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.cdi.util</groupId>
+      <artifactId>weft</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/DualOutputStreamsWrapper.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/DualOutputStreamsWrapper.java
@@ -1,0 +1,93 @@
+package org.commonjava.maven.galley.cache.infinispan;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * A output stream wrapper to let the stream writing to dual output stream. Will also wrap an ISPN cache
+ * transaction manager to manage the transaction commit/rollback when stream is closing.
+ */
+class DualOutputStreamsWrapper
+        extends OutputStream
+{
+
+    private OutputStream out1;
+
+    private OutputStream out2;
+
+    private TransactionManager cacheTxMgr;
+
+    public DualOutputStreamsWrapper( final OutputStream out1, final OutputStream out2,
+                                     final TransactionManager cacheTxMgr )
+    {
+        this.out1 = out1;
+        this.out2 = out2;
+        this.cacheTxMgr = cacheTxMgr;
+    }
+
+    @Override
+    public void write( int b )
+            throws IOException
+    {
+        out1.write( b );
+        out2.write( b );
+    }
+
+    public void write( byte b[] )
+            throws IOException
+    {
+        write( b, 0, b.length );
+    }
+
+    @Override
+    public void write( byte b[], int off, int len )
+            throws IOException
+    {
+        out1.write( b, off, len );
+        out2.write( b, off, len );
+    }
+
+    public void flush()
+            throws IOException
+    {
+        out1.flush();
+        out2.flush();
+    }
+
+    public void close()
+            throws IOException
+    {
+        final Logger logger = LoggerFactory.getLogger( getClass() );
+        try
+        {
+            out1.close();
+            out2.close();
+            cacheTxMgr.commit();
+        }
+        catch ( SystemException | RollbackException | HeuristicMixedException | HeuristicRollbackException | IOException e )
+        {
+            logger.error( "Transaction commit error for nfs cache during file writing.", e );
+
+            try
+            {
+                cacheTxMgr.rollback();
+            }
+            catch ( SystemException se )
+            {
+                logger.error( "Transaction rollback error for nfs cache during file writing.", se );
+            }
+            if ( e instanceof IOException )
+            {
+                throw (IOException) e;
+            }
+        }
+    }
+}

--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProvider.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProvider.java
@@ -1,0 +1,623 @@
+package org.commonjava.maven.galley.cache.infinispan;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.commonjava.cdi.util.weft.ExecutorConfig;
+import org.commonjava.cdi.util.weft.WeftManaged;
+import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProvider;
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
+import org.commonjava.maven.galley.spi.event.FileEventManager;
+import org.commonjava.maven.galley.spi.io.TransferDecorator;
+import org.commonjava.maven.galley.util.PathUtils;
+import org.infinispan.Cache;
+import org.infinispan.cdi.ConfigureCache;
+import org.infinispan.commons.util.concurrent.ConcurrentWeakKeyHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+/**
+ * This cache provider provides the ability to write the backup artifacts to an external storage(NFS) which can be mounted
+ * to local system as normal storage device, and meantime keep to cache these artifacts to local storage as usual. And a cache
+ * to store the usage ownership of the external storage will be hosted in this provider.
+ */
+@Named( "nfs-galley-cache" )
+@Alternative
+public class FastLocalCacheProvider
+        implements CacheProvider, CacheProvider.AdminView
+{
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    public static final String NFS_BASE_DIR_KEY = "galley.nfs.basedir";
+
+    private String nfsBaseDir;
+
+    private final Map<ConcreteResource, Transfer> transferCache = new ConcurrentWeakKeyHashMap<>( 10000 );
+
+    @Inject
+    @Named( "partyline-galley-cache" )
+    private PartyLineCacheProvider plCacheProvider;
+
+    // This NFS owner cache will be shared during nodes(indy?), it will record the which node is storing which file
+    // in NFS. Used as <path, ip> cache to collect nfs ownership of the file storage
+    @ConfigureCache( "nfs-owner-cache" )
+    @NFSOwnerCache
+    private Cache<String, String> nfsOwnerCache;
+
+    private TransactionManager cacheTxMgr;
+
+    @Inject
+    private FileEventManager fileEventManager;
+
+    @Inject
+    private TransferDecorator transferDecorator;
+
+    @ExecutorConfig( named = "fast-local-executor", threads = 5, priority = 2, daemon = true )
+    @WeftManaged
+    @Inject
+    private Executor executor;
+
+    protected FastLocalCacheProvider()
+    {
+        nfsBaseDir = System.getProperty( NFS_BASE_DIR_KEY );
+    }
+
+    public FastLocalCacheProvider( final PartyLineCacheProvider plCacheProvider,
+                                   final Cache<String, String> nfsUsageCache, final FileEventManager fileEventManager,
+                                   final TransferDecorator transferDecorator, final Executor executor )
+    {
+        this.plCacheProvider = plCacheProvider;
+        this.nfsOwnerCache = nfsUsageCache;
+        this.fileEventManager = fileEventManager;
+        this.transferDecorator = transferDecorator;
+        this.executor = executor;
+    }
+
+    public FastLocalCacheProvider( final PartyLineCacheProvider plCacheProvider,
+                                   final Cache<String, String> nfsUsageCache, final FileEventManager fileEventManager,
+                                   final TransferDecorator transferDecorator, final Executor executor,
+                                   final String nfsBaseDir )
+    {
+        this( plCacheProvider, nfsUsageCache, fileEventManager, transferDecorator, executor );
+        this.nfsBaseDir = nfsBaseDir;
+    }
+
+    @PostConstruct
+    public void init()
+    {
+        cacheTxMgr = nfsOwnerCache.getAdvancedCache().getTransactionManager();
+
+        startReporting();
+    }
+
+    @PreDestroy
+    public void destroy()
+    {
+        stopReporting();
+    }
+
+    @Override
+    public boolean isFileBased()
+    {
+        return true;
+    }
+
+    @Override
+    public File getDetachedFile( ConcreteResource resource )
+    {
+        //This Detached file is local one first, if not found will use nfs one.
+        File file = plCacheProvider.getDetachedFile( resource );
+        if ( file == null && StringUtils.isNotBlank( nfsBaseDir ) )
+        {
+            file = getNFSDetachedFile( resource );
+        }
+
+        return file;
+    }
+
+    private File getNFSDetachedFile( ConcreteResource resource )
+    {
+        String path = PathUtils.normalize( nfsBaseDir, getFilePath( resource ) );
+        return new File( path );
+    }
+
+    @Override
+    public void startReporting()
+    {
+        plCacheProvider.startReporting();
+    }
+
+    @Override
+    public void stopReporting()
+    {
+        plCacheProvider.stopReporting();
+    }
+
+    @Override
+    public void cleanupCurrentThread()
+    {
+        plCacheProvider.cleanupCurrentThread();
+    }
+
+    @Override
+    public boolean isDirectory( ConcreteResource resource )
+    {
+        return getDetachedFile( resource ).isDirectory();
+    }
+
+    @Override
+    public boolean isFile( ConcreteResource resource )
+    {
+        return getDetachedFile( resource ).isFile();
+    }
+
+    @Override
+    public InputStream openInputStream( final ConcreteResource resource )
+            throws IOException
+    {
+        boolean localExisted = plCacheProvider.exists( resource );
+        if ( !localExisted )
+        {
+            final String pathKey = getKeyForResource( resource );
+            executor.execute( new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    try
+                    {
+                        cacheTxMgr.begin();
+                        nfsOwnerCache.getAdvancedCache().lock( pathKey );
+                        File nfsFile = getNFSDetachedFile( resource );
+                        final InputStream nfsStream = new FileInputStream( nfsFile );
+                        final OutputStream localStream = plCacheProvider.openOutputStream( resource );
+                        IOUtils.copy( nfsStream, localStream );
+                    }
+                    catch ( NotSupportedException | SystemException | IOException e )
+                    {
+                        logger.error( "Cache TransactionManager got error, locking key is {}", new Object[] { pathKey },
+                                      e );
+                        throw new IllegalStateException( e );
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            cacheTxMgr.rollback();
+                        }
+                        catch ( SystemException e )
+                        {
+                            logger.error( "Cache TransactionManager rollback got error, locking key is {}",
+                                          new Object[] { pathKey }, e );
+                        }
+                    }
+                }
+            } );
+
+        }
+        return plCacheProvider.openInputStream( resource );
+    }
+
+    @Override
+    public OutputStream openOutputStream( ConcreteResource resource )
+            throws IOException
+    {
+        OutputStream dualOut = null;
+        try
+        {
+            cacheTxMgr.begin();
+            final String nodeIp = getCurrentNodeIp();
+            final String pathKey = getKeyForResource( resource );
+            //FIXME: putIfAbsent?
+            nfsOwnerCache.getAdvancedCache().lock( pathKey );
+            nfsOwnerCache.put( pathKey, nodeIp );
+            final OutputStream localOutputStream = plCacheProvider.openOutputStream( resource );
+            File nfsFile = getNFSDetachedFile( resource );
+            if ( !nfsFile.exists() && !nfsFile.isDirectory() )
+            {
+                try
+                {
+                    if ( !nfsFile.getParentFile().exists() )
+                    {
+                        nfsFile.getParentFile().mkdirs();
+                    }
+                    nfsFile.createNewFile();
+                }
+                catch ( IOException e )
+                {
+                    logger.error( "New nfs file created not properly.", e );
+                }
+            }
+            final OutputStream nfsOutputStream = new FileOutputStream( nfsFile );
+            dualOut = new DualOutputStreamsWrapper( localOutputStream, nfsOutputStream, cacheTxMgr );
+        }
+        catch ( NotSupportedException | SystemException e )
+        {
+            logger.error( "Transaction error for nfs cache during file writing.", e );
+            throw new IllegalStateException(
+                    String.format( "output stream for resource %s open failed.", resource.toString() ) );
+        }
+
+        return dualOut;
+    }
+
+    @Override
+    public boolean exists( ConcreteResource resource )
+    {
+        return plCacheProvider.exists( resource ) || getNFSDetachedFile( resource ).exists();
+    }
+
+    @Override
+    public void copy( ConcreteResource from, ConcreteResource to )
+            throws IOException
+    {
+        final String fromNFSPath = getKeyForResource( from );
+        final String toNFSPath = getKeyForResource( to );
+        try
+        {
+            cacheTxMgr.begin();
+            nfsOwnerCache.getAdvancedCache().lock( fromNFSPath, toNFSPath );
+            plCacheProvider.copy( from, to );
+            final FileInputStream nfsFrom = new FileInputStream( getNFSDetachedFile( from ) );
+            File nfsToFile = getNFSDetachedFile( to );
+            if ( !nfsToFile.exists() && !nfsToFile.isDirectory() )
+            {
+                if ( !nfsToFile.getParentFile().exists() )
+                {
+                    nfsToFile.getParentFile().mkdirs();
+                }
+                try
+                {
+                    nfsToFile.createNewFile();
+                }
+                catch ( IOException e )
+                {
+                    logger.error( "New nfs file created not properly.", e );
+                }
+            }
+            final OutputStream nfsTo = new FileOutputStream( nfsToFile );
+            IOUtils.copy( nfsFrom, nfsTo );
+            //FIXME: putIfAbsent? Or no need to put?
+            nfsOwnerCache.put( toNFSPath, getCurrentNodeIp() );
+            cacheTxMgr.commit();
+        }
+        catch ( NotSupportedException | SystemException | RollbackException | HeuristicMixedException | HeuristicRollbackException e )
+        {
+            logger.error( "Transaction error for nfs cache during file copying.", e );
+            try
+            {
+                cacheTxMgr.rollback();
+            }
+            catch ( SystemException se )
+            {
+                logger.error( "Transaction rollback error for nfs cache during file copying.", se );
+                throw new IllegalStateException( se );
+            }
+        }
+
+    }
+
+    @Override
+    public String getFilePath( ConcreteResource resource )
+    {
+        try
+        {
+            return getDetachedFile( resource ).getCanonicalPath();
+        }
+        catch ( IOException e )
+        {
+            logger.error( "File path not correctly got.", e );
+            throw new IllegalStateException( e );
+        }
+    }
+
+    @Override
+    public boolean delete( ConcreteResource resource )
+            throws IOException
+    {
+        final File nfsFile = getNFSDetachedFile( resource );
+        final String pathKey = getKeyForPath( nfsFile.getCanonicalPath() );
+        try
+        {
+            cacheTxMgr.begin();
+            nfsOwnerCache.getAdvancedCache().lock( pathKey );
+            final boolean localDeleted = plCacheProvider.delete( resource );
+            if ( !localDeleted )
+            {
+                logger.info( "local file deletion failed for {}", resource );
+            }
+            final boolean nfsDeleted = nfsFile.delete();
+            if ( !nfsDeleted )
+            {
+                logger.info( "nfs file deletion failed for {}", nfsFile );
+            }
+            nfsOwnerCache.remove( pathKey );
+            return localDeleted && nfsDeleted;
+        }
+        catch ( NotSupportedException | SystemException e )
+        {
+            logger.error( "Cache TransactionManager got error, locking key is {}", new Object[] { pathKey }, e );
+            throw new IllegalStateException( e );
+        }
+        finally
+        {
+            try
+            {
+                cacheTxMgr.rollback();
+            }
+            catch ( SystemException e )
+            {
+                logger.error( "Cache TransactionManager rollback got error, locking key is {}",
+                              new Object[] { pathKey }, e );
+            }
+        }
+    }
+
+    @Override
+    public String[] list( ConcreteResource resource )
+    {
+        // Only focus on NFS location
+        return getNFSDetachedFile( resource ).list();
+    }
+
+    @Override
+    public void mkdirs( ConcreteResource resource )
+            throws IOException
+    {
+        final String pathKey = getKeyForResource( resource );
+        try
+        {
+            cacheTxMgr.begin();
+            nfsOwnerCache.getAdvancedCache().lock( pathKey );
+            getDetachedFile( resource ).mkdirs();
+        }
+        catch ( NotSupportedException | SystemException e )
+        {
+            logger.error( "Cache TransactionManager got error, locking key is {}", new Object[] { pathKey }, e );
+            throw new IllegalStateException( e );
+        }
+        finally
+        {
+            try
+            {
+                cacheTxMgr.rollback();
+            }
+            catch ( SystemException e )
+            {
+                logger.error( "Cache TransactionManager rollback got error, locking key is {}",
+                              new Object[] { pathKey }, e );
+            }
+        }
+    }
+
+    @Deprecated
+    @Override
+    public void createFile( ConcreteResource resource )
+            throws IOException
+    {
+        final String pathKey = getKeyForResource( resource );
+        try
+        {
+            cacheTxMgr.begin();
+            nfsOwnerCache.getAdvancedCache().lock( pathKey );
+            final File nfsFile = getNFSDetachedFile( resource );
+            if ( !nfsFile.exists() )
+            {
+                nfsFile.getParentFile().mkdirs();
+                nfsFile.createNewFile();
+            }
+        }
+        catch ( NotSupportedException | SystemException e )
+        {
+            logger.error( "Cache TransactionManager got error, locking key is {}", new Object[] { pathKey }, e );
+            throw new IllegalStateException( e );
+        }
+        finally
+        {
+            try
+            {
+                cacheTxMgr.rollback();
+            }
+            catch ( SystemException e )
+            {
+                logger.error( "Cache TransactionManager rollback got error, locking key is {}",
+                              new Object[] { pathKey }, e );
+            }
+        }
+    }
+
+    @Deprecated
+    @Override
+    public void createAlias( ConcreteResource from, ConcreteResource to )
+            throws IOException
+    {
+        // if the download landed in a different repository, copy it to the current one for
+        // completeness..., and both in local and nfs sides
+        final Location fromKey = from.getLocation();
+        final Location toKey = to.getLocation();
+        final String fromPath = from.getPath();
+        final String toPath = to.getPath();
+
+        if ( fromKey != null && toKey != null && !fromKey.equals( toKey ) && fromPath != null && toPath != null
+                && !fromPath.equals( toPath ) )
+        {
+            copy( from, to );
+        }
+    }
+
+    @Override
+    public synchronized Transfer getTransfer( ConcreteResource resource )
+    {
+        Transfer t = transferCache.get( resource );
+        if ( t == null )
+        {
+            t = new Transfer( resource, this, fileEventManager, transferDecorator );
+            transferCache.put( resource, t );
+        }
+
+        return t;
+    }
+
+    @Override
+    public void clearTransferCache()
+    {
+        transferCache.clear();
+    }
+
+    @Override
+    public long length( ConcreteResource resource )
+    {
+        return getDetachedFile( resource ).length();
+    }
+
+    @Override
+    public long lastModified( ConcreteResource resource )
+    {
+        return getDetachedFile( resource ).lastModified();
+    }
+
+    @Override
+    public boolean isReadLocked( ConcreteResource resource )
+    {
+        return nfsOwnerCache.getAdvancedCache().getLockManager().isLocked( getKeyForResource( resource ) );
+    }
+
+    @Override
+    public boolean isWriteLocked( ConcreteResource resource )
+    {
+        // Use the same lock supplied by ISPN between write and read.
+        return isReadLocked( resource );
+    }
+
+    @Override
+    public void unlockRead( ConcreteResource resource )
+    {
+
+    }
+
+    @Override
+    public void unlockWrite( ConcreteResource resource )
+    {
+
+    }
+
+    @Override
+    public void lockRead( ConcreteResource resource )
+    {
+
+    }
+
+    @Override
+    public void lockWrite( ConcreteResource resource )
+    {
+
+    }
+
+    @Override
+    public void waitForReadUnlock( ConcreteResource resource )
+    {
+        while ( isReadLocked( resource ) )
+        {
+            logger.debug( "lock is still held for key {} by ISPN locker", getKeyForResource( resource ) );
+            try
+            {
+                // Use ISPN lock owner for resource to wait until lock is released. Note that if the lock has no owner,
+                // means lock has been released
+                final Object owner =
+                        nfsOwnerCache.getAdvancedCache().getLockManager().getOwner( getKeyForResource( resource ) );
+                if ( owner == null )
+                {
+                    break;
+                }
+                owner.wait( 1000 );
+            }
+            catch ( final InterruptedException e )
+            {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    @Override
+    public void waitForWriteUnlock( ConcreteResource resource )
+    {
+        // Use the same lock supplied by ISPN between write and read.
+        waitForReadUnlock( resource );
+    }
+
+    private String getCurrentNodeIp()
+            throws SocketException
+    {
+
+        final Enumeration<NetworkInterface> nis = NetworkInterface.getNetworkInterfaces();
+
+        while ( nis.hasMoreElements() )
+        {
+            final NetworkInterface ni = nis.nextElement();
+            final Enumeration<InetAddress> ips = ni.getInetAddresses();
+            while ( ips.hasMoreElements() )
+            {
+                final InetAddress ip = ips.nextElement();
+                if ( ip instanceof Inet4Address && ip.isSiteLocalAddress() )
+                {
+                    return ip.getHostAddress();
+                }
+            }
+        }
+
+        throw new IllegalStateException( "IP not found." );
+    }
+
+    private String getKeyForResource( ConcreteResource resource )
+    {
+        try
+        {
+            File nfsFile = getNFSDetachedFile( resource );
+            // Need the key as a parent folder level to lock all files I/O with some derivative files like checksum files
+            return getKeyForPath(
+                    nfsFile.isDirectory() ? nfsFile.getCanonicalPath() : nfsFile.getParentFile().getCanonicalPath() );
+        }
+        catch ( IOException e )
+        {
+            logger.error( "When get NFS cache key for resource: {}, got I/O error.", e );
+            throw new IllegalStateException( e );
+        }
+    }
+
+    private String getKeyForPath( String path )
+    {
+        //TODO: will directly return path now, may change some other way future(like digesting?)
+        return path;
+    }
+}

--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/NFSOwnerCache.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/NFSOwnerCache.java
@@ -1,0 +1,19 @@
+package org.commonjava.maven.galley.cache.infinispan;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifier used to supply cache for nfs owner in {@link org.commonjava.maven.galley.cache.infinispan.FastLocalCacheProvider}
+ */
+@Qualifier
+@Target( { ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD } )
+@Retention( RetentionPolicy.RUNTIME )
+@Documented
+public @interface NFSOwnerCache
+{
+}

--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/NFSOwnerCacheProducer.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/NFSOwnerCacheProducer.java
@@ -1,0 +1,61 @@
+package org.commonjava.maven.galley.cache.infinispan;
+
+import jdk.nashorn.internal.runtime.regexp.joni.Config;
+import org.infinispan.Cache;
+import org.infinispan.cdi.ConfigureCache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.EvictionConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.eviction.EvictionStrategy;
+import org.infinispan.eviction.EvictionType;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Produces;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Used to create the nfs cache using pre-defined cache configuration.
+ */
+@ApplicationScoped
+public class NFSOwnerCacheProducer
+{
+    static final String CACHE_NAME = "nfs-cache";
+
+    @ConfigureCache( CACHE_NAME )
+    @NFSOwnerCache
+    @Produces
+    @ApplicationScoped
+    public Configuration getCacheCfg()
+    {
+        return getCacheMgr().getCacheConfiguration( CACHE_NAME );
+    }
+
+    protected EmbeddedCacheManager getCacheMgr()
+    {
+        final EmbeddedCacheManager cacheManager = new DefaultCacheManager(
+                new GlobalConfigurationBuilder().globalJmxStatistics().jmxDomain( "org.commonjava" ).build() );
+        // Want to enable dead lock check as lock will be used in FastLocalCacheProvider
+        // and also set transaction mode to PESSIMISTIC with DummyTransactionManger.
+        final Configuration configuration = new ConfigurationBuilder().eviction()
+                                                                      .strategy( EvictionStrategy.LRU )
+                                                                      .size( 1000 )
+                                                                      .type( EvictionType.COUNT )
+                                                                      .deadlockDetection()
+                                                                      .spinDuration( 10, TimeUnit.SECONDS )
+                                                                      .enable()
+                                                                      .transaction()
+                                                                      .transactionManagerLookup(
+                                                                              new DummyTransactionManagerLookup() )
+                                                                      .lockingMode( LockingMode.PESSIMISTIC )
+                                                                      .build();
+        cacheManager.defineConfiguration( CACHE_NAME, configuration );
+        return cacheManager;
+    }
+}

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderTest.java
@@ -1,0 +1,90 @@
+package org.commonjava.maven.galley.cache.infinispan;
+
+import org.commonjava.cdi.util.weft.WeftManaged;
+import org.commonjava.maven.galley.cache.CacheProviderTCK;
+import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProvider;
+import org.commonjava.maven.galley.cache.testutil.TestFileEventManager;
+import org.commonjava.maven.galley.cache.testutil.TestTransferDecorator;
+import org.commonjava.maven.galley.io.HashedLocationPathGenerator;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
+import org.commonjava.maven.galley.spi.event.FileEventManager;
+import org.commonjava.maven.galley.spi.io.PathGenerator;
+import org.commonjava.maven.galley.spi.io.TransferDecorator;
+import org.infinispan.Cache;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+import java.io.File;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ */
+public class FastLocalCacheProviderTest
+        extends CacheProviderTCK
+{
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    @Rule
+    public TestName name = new TestName();
+
+    private FastLocalCacheProvider provider;
+
+    private static EmbeddedCacheManager CACHE_MANAGER;
+
+    @BeforeClass
+    public static void setupClass()
+    {
+        CACHE_MANAGER = new NFSOwnerCacheProducer().getCacheMgr();
+    }
+
+    @Before
+    public void setup()
+            throws Exception
+    {
+        final PathGenerator pathgen = new HashedLocationPathGenerator();
+        final FileEventManager events = new TestFileEventManager();
+        final TransferDecorator decorator = new TestTransferDecorator();
+
+        Cache<String, String> cache = CACHE_MANAGER.getCache( NFSOwnerCacheProducer.CACHE_NAME );
+
+        final String nfsBasePath = createNFSBaseDir( temp.newFolder().getAbsolutePath() );
+
+        final Executor executor = Executors.newFixedThreadPool( 5 );
+        provider =
+                new FastLocalCacheProvider( new PartyLineCacheProvider( temp.newFolder(), pathgen, events, decorator ),
+                                            cache, events, decorator, executor, nfsBasePath );
+        provider.init();
+    }
+
+    @Override
+    protected CacheProvider getCacheProvider()
+            throws Exception
+    {
+        return provider;
+    }
+
+    private String createNFSBaseDir( String tempBaseDir )
+    {
+        File file = new File( tempBaseDir + "/mnt/nfs" );
+        file.delete();
+        file.mkdir();
+        return file.getAbsolutePath();
+    }
+
+    @After
+    public void tearDown()
+    {
+        provider.destroy();
+    }
+
+}


### PR DESCRIPTION
Hi @jdcasey . I've fixed most of your comments for last commit, but still some stuff here:

For openOutputStream, you mentioned that we need some idle timeout way in the stream wrapper to handle lock releasing for stream no operation in seconds, I'm still confused how to do this? As I understand, when the txMgr.commit/rollback, the lock will be released. I've added these code snippet in the wrapper's close() in this commit. Need some clues to do this idle if this code snippet can not work.

And for the waitForXLock, I'm using the lock owner in ISPN cache to wait, which I think it can be better than the thread.sleep.