### PR TITLE
NOS-503 Create RoutingCacheProvider

### DIFF
--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/routes/RouteSelector.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/routes/RouteSelector.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.galley.cache.routes;
+
+import org.commonjava.maven.galley.model.ConcreteResource;
+
+public interface RouteSelector
+{
+    boolean isDisposable(ConcreteResource resource);
+}

--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/routes/RoutingCacheProviderFactory.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/routes/RoutingCacheProviderFactory.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.galley.cache.routes;
+
+import org.commonjava.maven.galley.GalleyInitException;
+import org.commonjava.maven.galley.cache.CacheProviderFactory;
+import org.commonjava.maven.galley.cache.infinispan.FastLocalCacheProvider;
+import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProvider;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
+import org.commonjava.maven.galley.spi.event.FileEventManager;
+import org.commonjava.maven.galley.spi.io.PathGenerator;
+import org.commonjava.maven.galley.spi.io.TransferDecorator;
+import org.infinispan.Cache;
+
+import java.io.File;
+import java.util.concurrent.ExecutorService;
+
+public class RoutingCacheProviderFactory
+        implements CacheProviderFactory
+{
+    private RouteSelector selector;
+
+    private CacheProvider disposable;
+
+    private CacheProvider safe;
+
+    private CacheProviderFactory disposableFactory;
+
+    private CacheProviderFactory safeFactory;
+
+    private transient RoutingCacheProviderWrapper provider;
+
+    public RoutingCacheProviderFactory( final RouteSelector selector, final CacheProvider disposable,
+                                        final CacheProvider safe )
+    {
+        this.selector = selector;
+        this.disposable = disposable;
+        this.safe = safe;
+    }
+
+    public RoutingCacheProviderFactory( final RouteSelector selector, final CacheProviderFactory disposableFactory,
+                                        final CacheProviderFactory safeFactory )
+    {
+        this.selector = selector;
+        this.disposableFactory = disposableFactory;
+        this.safeFactory = safeFactory;
+    }
+
+    @Override
+    public synchronized CacheProvider create( PathGenerator pathGenerator, TransferDecorator transferDecorator,
+                                              FileEventManager fileEventManager )
+            throws GalleyInitException
+    {
+        if ( provider == null )
+        {
+            if ( disposableFactory != null )
+            {
+                disposable = disposableFactory.create( pathGenerator, transferDecorator, fileEventManager );
+            }
+            if ( safeFactory != null )
+            {
+                safe = safeFactory.create( pathGenerator, transferDecorator, fileEventManager );
+            }
+            provider = new RoutingCacheProviderWrapper( selector, disposable, safe );
+        }
+
+        return provider;
+    }
+}

--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/routes/RoutingCacheProviderWrapper.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/routes/RoutingCacheProviderWrapper.java
@@ -1,0 +1,256 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.galley.cache.routes;
+
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
+
+import javax.enterprise.inject.Alternative;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+
+@Alternative
+public class RoutingCacheProviderWrapper
+        implements CacheProvider
+{
+    private final CacheProvider safe;
+
+    private final CacheProvider disposable;
+
+    private final RouteSelector selector;
+
+    public RoutingCacheProviderWrapper( final RouteSelector selector, final CacheProvider disposable,
+                                        final CacheProvider safe )
+    {
+        this.disposable = disposable;
+        this.safe = safe;
+        this.selector = selector;
+    }
+
+    protected CacheProvider getRoutedProvider( ConcreteResource resource )
+    {
+        if ( resource != null && disposable != null )
+        {
+            if ( selector.isDisposable( resource ) )
+            {
+                return disposable;
+            }
+
+        }
+        return safe;
+    }
+
+    @Override
+    public void startReporting()
+    {
+        if ( disposable != null )
+        {
+            disposable.startReporting();
+        }
+        if ( safe != null )
+        {
+            safe.startReporting();
+        }
+    }
+
+    @Override
+    public void stopReporting()
+    {
+        if ( disposable != null )
+        {
+            disposable.stopReporting();
+        }
+        if ( safe != null )
+        {
+            safe.stopReporting();
+        }
+    }
+
+    @Override
+    public void cleanupCurrentThread()
+    {
+        if ( disposable != null )
+        {
+            disposable.cleanupCurrentThread();
+        }
+        if ( safe != null )
+        {
+            safe.cleanupCurrentThread();
+        }
+    }
+
+    @Override
+    public boolean isDirectory( ConcreteResource resource )
+    {
+        return getRoutedProvider( resource ).isDirectory( resource );
+    }
+
+    @Override
+    public boolean isFile( ConcreteResource resource )
+    {
+        return getRoutedProvider( resource ).isFile( resource );
+    }
+
+    @Override
+    public InputStream openInputStream( ConcreteResource resource )
+            throws IOException
+    {
+        return getRoutedProvider( resource ).openInputStream( resource );
+    }
+
+    @Override
+    public OutputStream openOutputStream( ConcreteResource resource )
+            throws IOException
+    {
+        return getRoutedProvider( resource ).openOutputStream( resource );
+    }
+
+    @Override
+    public boolean exists( ConcreteResource resource )
+    {
+        return getRoutedProvider( resource ).exists( resource );
+    }
+
+    @Override
+    public void copy( ConcreteResource from, ConcreteResource to )
+            throws IOException
+    {
+        getRoutedProvider( from ).copy( from, to );
+    }
+
+    @Override
+    public String getFilePath( ConcreteResource resource )
+    {
+        return getRoutedProvider( resource ).getFilePath( resource );
+    }
+
+    @Override
+    public boolean delete( ConcreteResource resource )
+            throws IOException
+    {
+        return getRoutedProvider( resource ).delete( resource );
+    }
+
+    @Override
+    public String[] list( ConcreteResource resource )
+    {
+        return getRoutedProvider( resource ).list( resource );
+    }
+
+    @Override
+    public void mkdirs( ConcreteResource resource )
+            throws IOException
+    {
+        getRoutedProvider( resource ).mkdirs( resource );
+    }
+
+    @Override
+    public void createFile( ConcreteResource resource )
+            throws IOException
+    {
+        getRoutedProvider( resource ).createFile( resource );
+    }
+
+    @Override
+    public void createAlias( ConcreteResource from, ConcreteResource to )
+            throws IOException
+    {
+        getRoutedProvider( from ).createAlias( from, to );
+    }
+
+    @Override
+    public Transfer getTransfer( ConcreteResource resource )
+    {
+        return getRoutedProvider( resource ).getTransfer( resource );
+    }
+
+    @Override
+    public void clearTransferCache()
+    {
+        if ( disposable != null )
+        {
+            disposable.clearTransferCache();
+        }
+        if ( safe != null )
+        {
+            safe.clearTransferCache();
+        }
+    }
+
+    @Override
+    public long length( ConcreteResource resource )
+    {
+        return getRoutedProvider( resource ).length( resource );
+    }
+
+    @Override
+    public long lastModified( ConcreteResource resource )
+    {
+        return getRoutedProvider( resource ).lastModified( resource );
+    }
+
+    @Override
+    public boolean isReadLocked( ConcreteResource resource )
+    {
+        return getRoutedProvider( resource ).isReadLocked( resource );
+    }
+
+    @Override
+    public boolean isWriteLocked( ConcreteResource resource )
+    {
+        return getRoutedProvider( resource ).isWriteLocked( resource );
+    }
+
+    @Override
+    public void unlockRead( ConcreteResource resource )
+    {
+        getRoutedProvider( resource ).unlockRead( resource );
+    }
+
+    @Override
+    public void unlockWrite( ConcreteResource resource )
+    {
+        getRoutedProvider( resource ).unlockWrite( resource );
+    }
+
+    @Override
+    public void lockRead( ConcreteResource resource )
+    {
+        getRoutedProvider( resource ).lockRead( resource );
+    }
+
+    @Override
+    public void lockWrite( ConcreteResource resource )
+    {
+        getRoutedProvider( resource ).lockWrite( resource );
+    }
+
+    @Override
+    public void waitForWriteUnlock( ConcreteResource resource )
+    {
+        getRoutedProvider( resource ).waitForWriteUnlock( resource );
+    }
+
+    @Override
+    public void waitForReadUnlock( ConcreteResource resource )
+    {
+        getRoutedProvider( resource ).waitForReadUnlock( resource );
+    }
+}

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/routes/RoutingCacheProviderWrapperTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/routes/RoutingCacheProviderWrapperTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.galley.cache.routes;
+
+import org.commonjava.maven.galley.cache.CacheProviderFactory;
+import org.commonjava.maven.galley.cache.infinispan.FastLocalCacheProvider;
+import org.commonjava.maven.galley.cache.infinispan.FastLocalCacheProviderFactory;
+import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProvider;
+import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProviderFactory;
+import org.commonjava.maven.galley.cache.testutil.TestFileEventManager;
+import org.commonjava.maven.galley.cache.testutil.TestTransferDecorator;
+import org.commonjava.maven.galley.io.HashedLocationPathGenerator;
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.model.SimpleLocation;
+import org.commonjava.maven.galley.model.SpecialPathMatcher;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
+import org.commonjava.maven.galley.spi.event.FileEventManager;
+import org.commonjava.maven.galley.spi.io.PathGenerator;
+import org.commonjava.maven.galley.spi.io.TransferDecorator;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class RoutingCacheProviderWrapperTest
+{
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    private CacheProviderFactory partylineFac;
+
+    private CacheProviderFactory fastLocalFac;
+
+    private final PathGenerator pathgen = new HashedLocationPathGenerator();
+
+    private final FileEventManager events = new TestFileEventManager();
+
+    private final TransferDecorator decorator = new TestTransferDecorator();
+
+    private final RouteSelector selector = new RouteSelector()
+    {
+        @Override
+        public boolean isDisposable( ConcreteResource resource )
+        {
+            if ( resource != null )
+            {
+                String pattern = "^hosted:.*$";
+                final Location loc = resource.getLocation();
+                if ( loc != null )
+                {
+                    final String uri = loc.getUri();
+                    synchronized ( this )
+                    {
+                        return uri != null && uri.matches( pattern );
+                    }
+                }
+            }
+            return false;
+        }
+    };
+
+    @Before
+    public void prepare()
+            throws Exception
+    {
+
+        final File cacheDir = temp.newFolder();
+        partylineFac = new PartyLineCacheProviderFactory( cacheDir );
+        fastLocalFac = new FastLocalCacheProviderFactory( cacheDir, temp.newFolder(), null,
+                                                          Executors.newFixedThreadPool( 5 ) );
+    }
+
+    @Test
+    public void test()
+            throws Exception
+    {
+
+        final RoutingCacheProviderWrapper router =
+                (RoutingCacheProviderWrapper) new RoutingCacheProviderFactory( selector, fastLocalFac,
+                                                                               partylineFac ).create( pathgen,
+                                                                                                      decorator,
+                                                                                                      events );
+        final CacheProvider partyline = partylineFac.create( pathgen, decorator, events );
+        final CacheProvider fastLocal = fastLocalFac.create( pathgen, decorator, events );
+
+        final String fname = "/path/to/my/file.txt";
+        Location loc = new SimpleLocation( "remote:foo/com" );
+        ConcreteResource resource = new ConcreteResource( loc, fname );
+        CacheProvider get = router.getRoutedProvider( resource );
+        assertThat( get, equalTo( partyline ) );
+
+        loc = new SimpleLocation( "hosted:foo/com" );
+        resource = new ConcreteResource( loc, fname );
+        get = router.getRoutedProvider( resource );
+        assertThat( get, equalTo( fastLocal ) );
+
+        loc = new SimpleLocation( "group:foo/com" );
+        resource = new ConcreteResource( loc, fname );
+        get = router.getRoutedProvider( resource );
+        assertThat( get, equalTo( partyline ) );
+
+        loc = new SimpleLocation( "http://foo.com" );
+        resource = new ConcreteResource( loc, fname );
+        get = router.getRoutedProvider( resource );
+        assertThat( get, equalTo( partyline ) );
+
+        resource = new ConcreteResource( null, null );
+        get = router.getRoutedProvider( resource );
+        assertThat( get, equalTo( partyline ) );
+
+        get = router.getRoutedProvider( null );
+        assertThat( get, equalTo( partyline ) );
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
       </dependency>
       <dependency>
         <groupId>org.commonjava.maven.galley</groupId>
+        <artifactId>galley-cache-infinispan</artifactId>
+        <version>0.13.2-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.maven.galley</groupId>
         <artifactId>galley-cache-tck</artifactId>
         <version>0.13.3-SNAPSHOT</version>
         <scope>test</scope>


### PR DESCRIPTION
Hi, @jdcasey 

The scope of the getRoutedProvider method has been limited to protected in this PR

And for that TestRoutingCacheProvider, I think it is not needed because the getRoutedProvider is still accessible in the test because it is in the same package with class for testing. I think this is a trick we usually used for the unit-testing. :)