### PR TITLE
Did some changes for FastLocalCacheProvider

### DIFF
--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProvider.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProvider.java
@@ -75,8 +75,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * as this provider will use it to get the nfs root directory by default. If you want to set this directory by manually,
  * use the parameterized constructor with the "nfsBaseDir" param.
  */
-@Named( "nfs-galley-cache" )
-@Alternative
 public class FastLocalCacheProvider
         implements CacheProvider, CacheProvider.AdminView
 {
@@ -92,36 +90,21 @@ public class FastLocalCacheProvider
 
     private final Map<String, Set<WeakReference<OutputStream>>> streamHolder = new HashMap<>( 50 );
 
-    @Inject
-    @Named( "partyline-galley-cache" )
     private PartyLineCacheProvider plCacheProvider;
 
     // This NFS owner cache will be shared during nodes(indy?), it will record the which node is storing which file
     // in NFS. Used as <path, ip> cache to collect nfs ownership of the file storage
-    @ConfigureCache( NFSOwnerCacheProducer.CACHE_NAME )
-    @NFSOwnerCache
     private Cache<String, String> nfsOwnerCache;
 
     private TransactionManager cacheTxMgr;
 
-    @Inject
     private FileEventManager fileEventManager;
 
-    @Inject
     private TransferDecorator transferDecorator;
 
-    @ExecutorConfig( named = "fast-local-executor", threads = 5, priority = 2, daemon = true )
-    @WeftManaged
-    @Inject
     private ExecutorService executor;
 
     private PathGenerator pathGenerator;
-
-    protected FastLocalCacheProvider()
-    {
-        nfsBaseDir = System.getProperty( NFS_BASE_DIR_KEY );
-        checkNfsBaseDir();
-    }
 
     /**
      * Construct the FastLocalCacheProvider with the params. Note that this constructor will set the NFS root directory using
@@ -138,7 +121,6 @@ public class FastLocalCacheProvider
                                    final FileEventManager fileEventManager, final TransferDecorator transferDecorator,
                                    final ExecutorService executor )
     {
-        this();
         this.plCacheProvider = plCacheProvider;
         this.nfsOwnerCache = nfsUsageCache;
         this.pathGenerator = pathGenerator;

--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/NFSOwnerCacheProducer.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/NFSOwnerCacheProducer.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 @ApplicationScoped
 public class NFSOwnerCacheProducer
 {
-    static final String CACHE_NAME = "nfs-cache";
+    public static final String CACHE_NAME = "nfs-cache";
 
     @ConfigureCache( CACHE_NAME )
     @NFSOwnerCache

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderTest.java
@@ -145,39 +145,9 @@ public class FastLocalCacheProviderTest
         assertThat( result, equalTo( content ) );
     }
 
+
     @Test( expected = java.lang.IllegalArgumentException.class )
     public void testConstructorWitNoNFSSysPath()
-    {
-        new FastLocalCacheProvider();
-    }
-
-    @Test( expected = java.lang.IllegalArgumentException.class )
-    public void testConstructorWitNoNFSSysPath2()
-            throws IOException
-    {
-        final String NON_EXISTS_PATH = "/mnt/nfs/abc/xyz";
-        System.setProperty( FastLocalCacheProvider.NFS_BASE_DIR_KEY, NON_EXISTS_PATH );
-        new FastLocalCacheProvider();
-    }
-
-    @Test( expected = java.lang.IllegalArgumentException.class )
-    public void testConstructorWitNoNFSSysPath3()
-            throws IOException
-    {
-        System.setProperty( FastLocalCacheProvider.NFS_BASE_DIR_KEY, temp.newFile().getCanonicalPath() );
-        new FastLocalCacheProvider();
-    }
-
-    @Test( expected = java.lang.IllegalArgumentException.class )
-    public void testConstructorWitNoNFSSysPath4()
-            throws IOException
-    {
-        new FastLocalCacheProvider( new PartyLineCacheProvider( temp.newFolder(), pathgen, events, decorator ), cache,
-                                    pathgen, events, decorator, executor );
-    }
-
-    @Test( expected = java.lang.IllegalArgumentException.class )
-    public void testConstructorWitNoNFSSysPath5()
             throws IOException
     {
         final String NON_EXISTS_PATH = "/mnt/nfs/abc/xyz";
@@ -190,7 +160,6 @@ public class FastLocalCacheProviderTest
             throws IOException
     {
         System.setProperty( FastLocalCacheProvider.NFS_BASE_DIR_KEY, temp.newFolder().getCanonicalPath() );
-        new FastLocalCacheProvider();
         new FastLocalCacheProvider( new PartyLineCacheProvider( temp.newFolder(), pathgen, events, decorator ), cache,
                                     pathgen, events, decorator, executor );
     }


### PR DESCRIPTION
  1. Removes the CDI part of FastLocalCacheProvider
  2. Removes the default no-args constructor of FastLocalCacheProvider
  3. Extends the NFSOwnerCache config name for external useage
  4. Removes the test cases for no-args constructor of FastLocalCacheProvider