### PR TITLE
Some fix for FastLocalCacheProvider

### DIFF
--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/NFSOwnerCacheProducer.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/NFSOwnerCacheProducer.java
@@ -55,7 +55,7 @@ public class NFSOwnerCacheProducer
     protected EmbeddedCacheManager getCacheMgr()
     {
         final EmbeddedCacheManager cacheManager = new DefaultCacheManager(
-                new GlobalConfigurationBuilder().globalJmxStatistics().jmxDomain( "org.commonjava" ).build() );
+                new GlobalConfigurationBuilder().globalJmxStatistics().jmxDomain( "org.commonjava.maven.galley" ).build() );
         // Want to enable dead lock check as lock will be used in FastLocalCacheProvider
         // and also set transaction mode to PESSIMISTIC with DummyTransactionManger.
         final Configuration configuration = new ConfigurationBuilder().eviction()

--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/routes/RoutingCacheProviderWrapper.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/routes/RoutingCacheProviderWrapper.java
@@ -19,6 +19,8 @@ import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.spi.cache.CacheProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.enterprise.inject.Alternative;
 import java.io.IOException;
@@ -30,6 +32,8 @@ import java.util.Map;
 public class RoutingCacheProviderWrapper
         implements CacheProvider
 {
+    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
     private final CacheProvider safe;
 
     private final CacheProvider disposable;
@@ -50,10 +54,11 @@ public class RoutingCacheProviderWrapper
         {
             if ( selector.isDisposable( resource ) )
             {
+                logger.debug("Used disposable cache provider {}", disposable);
                 return disposable;
             }
-
         }
+        logger.debug("Used safe cache provider {}", safe);
         return safe;
     }
 

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/AbstractFastLocalCacheBMUnitTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/AbstractFastLocalCacheBMUnitTest.java
@@ -82,7 +82,6 @@ public class AbstractFastLocalCacheBMUnitTest
         provider =
                 new FastLocalCacheProvider( new PartyLineCacheProvider( temp.newFolder(), pathgen, events, decorator ),
                                             cache, pathgen, events, decorator, executor, nfsBasePath );
-        provider.init();
     }
 
     @After

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderConcurrentTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderConcurrentTest.java
@@ -103,7 +103,6 @@ public class FastLocalCacheProviderConcurrentTest
         provider =
                 new FastLocalCacheProvider( plProvider,
                                             cache, pathgen, events, decorator, executor, nfsBasePath );
-        provider.init();
     }
 
     @Test

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderTest.java
@@ -150,7 +150,7 @@ public class FastLocalCacheProviderTest
     public void testConstructorWitNoNFSSysPath()
             throws IOException
     {
-        final String NON_EXISTS_PATH = "/mnt/nfs/abc/xyz";
+        final String NON_EXISTS_PATH = "";
         new FastLocalCacheProvider( new PartyLineCacheProvider( temp.newFolder(), pathgen, events, decorator ), cache,
                                     pathgen, events, decorator, executor, NON_EXISTS_PATH );
     }

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/routes/RoutingCacheProviderWrapperTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/routes/RoutingCacheProviderWrapperTest.java
@@ -18,6 +18,7 @@ package org.commonjava.maven.galley.cache.routes;
 import org.commonjava.maven.galley.cache.CacheProviderFactory;
 import org.commonjava.maven.galley.cache.infinispan.FastLocalCacheProvider;
 import org.commonjava.maven.galley.cache.infinispan.FastLocalCacheProviderFactory;
+import org.commonjava.maven.galley.cache.infinispan.NFSOwnerCacheProducer;
 import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProvider;
 import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProviderFactory;
 import org.commonjava.maven.galley.cache.testutil.TestFileEventManager;
@@ -31,6 +32,7 @@ import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.maven.galley.spi.event.FileEventManager;
 import org.commonjava.maven.galley.spi.io.PathGenerator;
 import org.commonjava.maven.galley.spi.io.TransferDecorator;
+import org.infinispan.manager.DefaultCacheManager;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -90,7 +92,7 @@ public class RoutingCacheProviderWrapperTest
 
         final File cacheDir = temp.newFolder();
         partylineFac = new PartyLineCacheProviderFactory( cacheDir );
-        fastLocalFac = new FastLocalCacheProviderFactory( cacheDir, temp.newFolder(), null,
+        fastLocalFac = new FastLocalCacheProviderFactory( cacheDir, temp.newFolder(), new DefaultCacheManager().<String, String>getCache(),
                                                           Executors.newFixedThreadPool( 5 ) );
     }
 


### PR DESCRIPTION
  1. For infinispan cache cofnig, changes the jmx domain config to galley
  2. Changes some nfs root dir check rules, just check if it is blank
  3. Will create the nfs root dir in getNFSDetachedFile if it does not exist
  4. Wraps the init method into constructors of FastLocalCacheProvider to let it always run after construction
  5. Adds two debug log in RoutingCacheProviderWrapper
  6. Changes the DualOutputStreamWrapper.close method to let it always close the wrapped streams even if Exception
  4. Changes unit-test due to these changes