### PR TITLE
Write http-metadata.json filee up front instead of after the transfer completes

### DIFF
--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
@@ -78,12 +78,17 @@ public final class HttpDownload
         }
         finally
         {
-            writeMetadata( target, mapper );
             cleanup();
         }
 
         logger.info( "Download attempt done: {} Result:\n  target: {}\n  error: {}", url, target, error );
         return this;
+    }
+
+    @Override
+    protected ObjectMapper getMetadataObjectMapper()
+    {
+        return mapper;
     }
 
     @Override

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpExistence.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpExistence.java
@@ -59,11 +59,21 @@ public final class HttpExistence
         }
         finally
         {
-            writeMetadata( transfer, mapper );
             cleanup();
         }
 
         return false;
     }
 
+    @Override
+    protected Transfer getTransfer()
+    {
+        return transfer;
+    }
+
+    @Override
+    protected ObjectMapper getMetadataObjectMapper()
+    {
+        return mapper;
+    }
 }


### PR DESCRIPTION
@jdcasey Fixed according to your comment with a small twist. I make changes in HttpDownload and HttpExistence rather than their super abstract class because writeMetadata() takes parameters which are conveniently available in derived classes. This is the minimal code change. Further, it is not as good to distinguish GET/HEAD request from others in the super class as to distinguish those via natural polymorphism in derived classes. A ftest is added to Indy. 