### PR TITLE
Fix memleak issue in PartyLineCacheProvider

### DIFF
--- a/caches/partyline/src/main/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProvider.java
+++ b/caches/partyline/src/main/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProvider.java
@@ -402,7 +402,7 @@ public class PartyLineCacheProvider
         if ( t == null )
         {
             t = new Transfer( resource, this, fileEventManager, transferDecorator );
-            transferCache.put( resource, t );
+            transferCache.put( new ConcreteResource( resource.getLocation(), resource.getPath() ), t );
         }
 
         return t;


### PR DESCRIPTION
The value object Transfer holds a strong reference to key object ConcreteResource so that entries could never be GC collected. Making a copy of key object fixes this issue. I verified it via my tiny little test program. However, Zhiming needs 12 hours to redo his perf test. Let's wait for his report. 