### PR TITLE
Introduce ability to force checksumming and delete checksums from consumer

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/event/EventMetadata.java
+++ b/api/src/main/java/org/commonjava/maven/galley/event/EventMetadata.java
@@ -39,6 +39,12 @@ public class EventMetadata
         this.packageType = packageType;
     }
 
+    public EventMetadata( final EventMetadata original )
+    {
+        this.packageType = original.packageType;
+        this.metadata.putAll( original.metadata );
+    }
+
     public Map<Object, Object> getMetadata()
     {
         return metadata;

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingInputStream.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingInputStream.java
@@ -20,10 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.FilterInputStream;
-import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -87,7 +85,7 @@ public final class ChecksummingInputStream
 
         if ( metadataConsumer != null )
         {
-            metadataConsumer.accept( transfer, new TransferMetadata( hexDigests, size ) );
+            metadataConsumer.addMetadata( transfer, new TransferMetadata( hexDigests, size ) );
         }
     }
 

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStream.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStream.java
@@ -85,7 +85,7 @@ public final class ChecksummingOutputStream
 
         if ( metadataConsumer != null )
         {
-            metadataConsumer.accept( transfer, new TransferMetadata( hexDigests, size ) );
+            metadataConsumer.addMetadata( transfer, new TransferMetadata( hexDigests, size ) );
         }
     }
 

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/TransferMetadataConsumer.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/TransferMetadataConsumer.java
@@ -7,5 +7,7 @@ import org.commonjava.maven.galley.model.Transfer;
  */
 public interface TransferMetadataConsumer
 {
-    void accept( Transfer transfer, TransferMetadata transferData );
+    void addMetadata( Transfer transfer, TransferMetadata transferData );
+
+    void removeMetadata( Transfer transfer );
 }


### PR DESCRIPTION
In some cases we need to be able to override the way ChecksummingTransferDecorator
is initialized, to force it to calculate checksums on a read, for instance, when
reader checksumming isn't enabled.

We can use EventMetadata for this. By setting a flag in the EventMetadata we can
override the base configuration of the decorator.