### PR TITLE
Log content deletion to a logger specifically named for the purpose

### DIFF
--- a/core/src/main/java/org/commonjava/maven/galley/internal/TransferManagerImpl.java
+++ b/core/src/main/java/org/commonjava/maven/galley/internal/TransferManagerImpl.java
@@ -71,6 +71,7 @@ import java.util.concurrent.Future;
 import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.apache.commons.io.IOUtils.copy;
 import static org.apache.commons.lang.StringUtils.join;
+import static org.commonjava.maven.galley.model.Transfer.DELETE_CONTENT_LOG;
 import static org.commonjava.maven.galley.util.LocationUtils.getTimeoutSeconds;
 
 @ApplicationScoped
@@ -706,7 +707,8 @@ public class TransferManagerImpl
             return false;
         }
 
-        logger.info( "DELETE begins in transfer manager: {}", item.getResource() );
+        Logger contentLogger = LoggerFactory.getLogger( DELETE_CONTENT_LOG );
+        contentLogger.info( "BEGIN: Delete {} ({})", item.getResource(), eventMetadata );
 
         SpecialPathInfo specialPathInfo = specialPathManager.getSpecialPathInfo( item, eventMetadata.getPackageType() );
         if ( specialPathInfo != null && !specialPathInfo.isDeletable() )
@@ -731,6 +733,7 @@ public class TransferManagerImpl
             {
                 if ( !doDelete( item.getChild( sub ), eventMetadata ) )
                 {
+                    contentLogger.info( "FAIL: Delete: {}", item.getResource() );
                     return false;
                 }
             }
@@ -750,6 +753,8 @@ public class TransferManagerImpl
                                              e.getMessage() );
             }
         }
+
+        contentLogger.info( "FINISH: Delete: {}", item.getResource() );
 
         return true;
     }


### PR DESCRIPTION
This uses a separate logger, with the 'org.commonjava' base namespace, an
intermediate namespace of 'content' (for any content action), and a
specific name of 'delete'. This will allow us to isolate these messages
from others and push them to a different log appender. We should also
be able to reuse the name for any location where content is being deleted
in Commonjava libraries / applications.

This PR supercedes @ligangty's. Thanks for doing the initial work!