### PR TITLE
Use base namespace of org.commonjava.topic for topical logs

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/model/Transfer.java
+++ b/api/src/main/java/org/commonjava/maven/galley/model/Transfer.java
@@ -39,7 +39,7 @@ import static org.apache.commons.lang.StringUtils.join;
 public class Transfer
 {
 
-    public static final String DELETE_CONTENT_LOG = "org.commonjava.content.delete";
+    public static final String DELETE_CONTENT_LOG = "org.commonjava.topic.content.delete";
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 


### PR DESCRIPTION
This should give us a little more control over configuring topical
log namespaces as a group. All logs in commonjava start with
org.commonjava, so it would be hard to manage topical ones separately
from package-derived ones. This change fixes that (partially)...
we still can't manage package-derived ones as a group without
catching topical ones too.