### PR TITLE
FORCE_CHECKSUM should override SpecialPathInfo.isDecoratable()

### DIFF
--- a/core/src/main/java/org/commonjava/maven/galley/io/ChecksummingTransferDecorator.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/ChecksummingTransferDecorator.java
@@ -112,7 +112,7 @@ public final class ChecksummingTransferDecorator
             logger.trace( "SpecialPathInfo for: {} is: {} (decoratable? {})", transfer, specialPathInfo,
                           ( specialPathInfo == null ? true : specialPathInfo.isDecoratable() ) );
 
-            if ( specialPathInfo == null || specialPathInfo.isDecoratable() )
+            if ( force || specialPathInfo == null || specialPathInfo.isDecoratable() )
             {
                 // Cases when we want to do checksumming:
                 // 0. if we're forcing recalculation
@@ -148,7 +148,7 @@ public final class ChecksummingTransferDecorator
             logger.trace( "SpecialPathInfo for: {} is: {} (decoratable? {})", transfer, specialPathInfo,
                           ( specialPathInfo == null ? true : specialPathInfo.isDecoratable() ) );
 
-            if ( specialPathInfo == null || specialPathInfo.isDecoratable() )
+            if ( force || specialPathInfo == null || specialPathInfo.isDecoratable() )
             {
                 logger.trace( "Wrapping input stream to: {} for checksum generation.", transfer );
                 boolean writeChecksums = force || writeChecksumFilesOn == null || writeChecksumFilesOn.isEmpty()


### PR DESCRIPTION
Without allowing FORCE_CHECKSUM to override SpecialPathInfo.isDecoratable(),
there isn't a good way to get checksum / size metadata for things like Maven
.sha1 files. It's a little meta that we want checksums for a checksum file,
but the Indy tracking record does actually record this.

This change makes FORCE_CHECKSUM even more forceful, overriding consideration
of whether the path can be decorated given by SpecialPathInfo.