### PR TITLE
Refactor ChecksummingTransferDecorator to accept two ChecksummingDecoratorAdvisors, one for read, one for write

### DIFF
--- a/core/src/main/java/org/commonjava/maven/galley/io/DeprecatedChecksummingFilter.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/DeprecatedChecksummingFilter.java
@@ -1,0 +1,84 @@
+package org.commonjava.maven.galley.io;
+
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.io.checksum.ChecksummingDecoratorAdvisor;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.commonjava.maven.galley.io.checksum.ChecksummingDecoratorAdvisor.ChecksumAdvice.CALCULATE_AND_WRITE;
+import static org.commonjava.maven.galley.io.checksum.ChecksummingDecoratorAdvisor.ChecksumAdvice.CALCULATE_NO_WRITE;
+import static org.commonjava.maven.galley.io.checksum.ChecksummingDecoratorAdvisor.ChecksumAdvice.NO_DECORATE;
+
+/**
+ * Support deprecated constructors in {@link ChecksummingTransferDecorator} which used old boolean-and-set style to
+ * determine when checksums should be calculated vs written. This class adapts that old style to the new style based on
+ * {@link ChecksummingDecoratorAdvisor}.
+ *
+ * Created by jdcasey on 5/5/17.
+ */
+@Deprecated
+public class DeprecatedChecksummingFilter
+        implements ChecksummingDecoratorAdvisor
+{
+    private final boolean enabled;
+
+    private final Set<TransferOperation> writeOperations;
+
+    /**
+     * Create a new filter instance using the old style of enabled + allowable-write-operations. If the operation for
+     * a given transfer is in writeOperations, this signals that checksums should be calculated AND written to
+     * checksum files.
+     *
+     * @param enabled Whether checksumming is enabled at all for this type of operation (file read / write)
+     * @param writeOperations Set of {@link TransferOperation}'s for which checksum-file writing is enabled for this
+     * filter
+     */
+    public DeprecatedChecksummingFilter( final boolean enabled,
+                                         final Set<TransferOperation> writeOperations )
+    {
+        this.enabled = enabled;
+        this.writeOperations = writeOperations == null ? Collections.<TransferOperation> emptySet() : writeOperations;
+    }
+
+    /**
+     * If the filter is not enabled, return {@link ChecksumAdvice#NO_DECORATE}. Otherwise:
+     * <ul>
+     *     <li>If the operation matches one of the {@link TransferOperation}'s specifically enabled for this
+     *     type of decorator (reader vs. writer), return (@link FilterAdvice#CALCULATE_AND_WRITE}</li>
+     *     <li>Otherwise, return {@link ChecksumAdvice#CALCULATE_NO_WRITE}</li>
+     * </ul>
+     */
+    @Override
+    public ChecksumAdvice getDecorationAdvice( final Transfer transfer, final TransferOperation operation,
+                                               final EventMetadata eventMetadata )
+    {
+        if ( !enabled )
+        {
+            return NO_DECORATE;
+        }
+
+        if ( writeOperations.contains( operation ) )
+        {
+            return CALCULATE_AND_WRITE;
+        }
+
+        return CALCULATE_NO_WRITE;
+    }
+
+    public static Set<TransferOperation> calculateWriteOperations( final Set<TransferOperation> enabledForDecorator,
+                                                 final TransferOperation... enabledForFilter)
+    {
+        Set<TransferOperation> writeOperations = enabledForDecorator == null ?
+                new HashSet<TransferOperation>() :
+                new HashSet<TransferOperation>( enabledForDecorator );
+
+        writeOperations.retainAll( Arrays.asList( enabledForFilter ) );
+
+        return writeOperations;
+    }
+}

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/AbstractChecksumGeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/AbstractChecksumGeneratorFactory.java
@@ -26,13 +26,20 @@ public abstract class AbstractChecksumGeneratorFactory<T extends AbstractChecksu
     {
     }
 
+    @Deprecated
     public final T createGenerator( final Transfer transfer )
         throws IOException
     {
-        return newGenerator( transfer );
+        return createGenerator( transfer, true );
     }
 
-    protected abstract T newGenerator( Transfer transfer )
+    public final T createGenerator( final Transfer transfer, boolean writeChecksumFiles )
+            throws IOException
+    {
+        return newGenerator( transfer, writeChecksumFiles );
+    }
+
+    protected abstract T newGenerator( Transfer transfer, boolean writeChecksumFiles )
         throws IOException;
 
 }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingDecoratorAdvisor.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingDecoratorAdvisor.java
@@ -1,0 +1,20 @@
+package org.commonjava.maven.galley.io.checksum;
+
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+
+/**
+ * Created by jdcasey on 5/5/17.
+ */
+public interface ChecksummingDecoratorAdvisor
+{
+    enum ChecksumAdvice
+    {
+        NO_DECORATE,
+        CALCULATE_NO_WRITE,
+        CALCULATE_AND_WRITE;
+    }
+
+    ChecksumAdvice getDecorationAdvice( Transfer transfer, TransferOperation operation, EventMetadata eventMetadata );
+}

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStream.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStream.java
@@ -44,13 +44,6 @@ public final class ChecksummingOutputStream
     private final boolean writeChecksumFiles;
 
     public ChecksummingOutputStream( final Set<AbstractChecksumGeneratorFactory<?>> checksumFactories,
-                                     final OutputStream stream, final Transfer transfer )
-            throws IOException
-    {
-        this( checksumFactories, stream, transfer, null, true );
-    }
-
-    public ChecksummingOutputStream( final Set<AbstractChecksumGeneratorFactory<?>> checksumFactories,
                                      final OutputStream stream, final Transfer transfer,
                                      final TransferMetadataConsumer metadataConsumer, final boolean writeChecksumFiles )
         throws IOException
@@ -59,10 +52,10 @@ public final class ChecksummingOutputStream
         this.transfer = transfer;
         this.metadataConsumer = metadataConsumer;
         this.writeChecksumFiles = writeChecksumFiles;
-        checksums = new HashSet<AbstractChecksumGenerator>();
+        checksums = new HashSet<>();
         for ( final AbstractChecksumGeneratorFactory<?> factory : checksumFactories )
         {
-            checksums.add( factory.createGenerator( transfer ) );
+            checksums.add( factory.createGenerator( transfer, writeChecksumFiles ) );
         }
     }
 

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/DisabledChecksummingDecoratorAdvisor.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/DisabledChecksummingDecoratorAdvisor.java
@@ -1,0 +1,21 @@
+package org.commonjava.maven.galley.io.checksum;
+
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+
+import static org.commonjava.maven.galley.io.checksum.ChecksummingDecoratorAdvisor.ChecksumAdvice.NO_DECORATE;
+
+/**
+ * Created by jdcasey on 5/5/17.
+ */
+public class DisabledChecksummingDecoratorAdvisor
+        implements ChecksummingDecoratorAdvisor
+{
+    @Override
+    public ChecksumAdvice getDecorationAdvice( final Transfer transfer, final TransferOperation operation,
+                                               final EventMetadata eventMetadata )
+    {
+        return NO_DECORATE;
+    }
+}

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Md5GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Md5GeneratorFactory.java
@@ -29,20 +29,20 @@ public final class Md5GeneratorFactory
     }
 
     @Override
-    protected Md5Generator newGenerator( final Transfer transfer )
+    protected Md5Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile )
         throws IOException
     {
-        return new Md5Generator( transfer );
+        return new Md5Generator( transfer, writeChecksumFile );
     }
 
     public static final class Md5Generator
         extends AbstractChecksumGenerator
     {
 
-        protected Md5Generator( final Transfer transfer )
+        protected Md5Generator( final Transfer transfer, final boolean writeChecksumFile )
             throws IOException
         {
-            super( transfer, ".md5", ContentDigest.MD5 );
+            super( transfer, ".md5", ContentDigest.MD5, writeChecksumFile );
         }
 
     }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha1GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha1GeneratorFactory.java
@@ -29,20 +29,20 @@ public final class Sha1GeneratorFactory
     }
 
     @Override
-    protected Sha1Generator newGenerator( final Transfer transfer )
+    protected Sha1Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile )
         throws IOException
     {
-        return new Sha1Generator( transfer );
+        return new Sha1Generator( transfer, writeChecksumFile );
     }
 
     public static final class Sha1Generator
         extends AbstractChecksumGenerator
     {
 
-        protected Sha1Generator( final Transfer transfer )
+        protected Sha1Generator( final Transfer transfer, final boolean writeChecksumFile )
             throws IOException
         {
-            super( transfer, ".sha1", ContentDigest.SHA_1 );
+            super( transfer, ".sha1", ContentDigest.SHA_1, writeChecksumFile );
         }
 
     }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha256GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha256GeneratorFactory.java
@@ -29,20 +29,20 @@ public final class Sha256GeneratorFactory
     }
 
     @Override
-    protected Sha256Generator newGenerator( final Transfer transfer )
+    protected Sha256Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile )
         throws IOException
     {
-        return new Sha256Generator( transfer );
+        return new Sha256Generator( transfer, writeChecksumFile );
     }
 
     public static final class Sha256Generator
         extends AbstractChecksumGenerator
     {
 
-        protected Sha256Generator( final Transfer transfer )
+        protected Sha256Generator( final Transfer transfer, final boolean writeChecksumFile )
             throws IOException
         {
-            super( transfer, ".sha256", ContentDigest.SHA_256 );
+            super( transfer, ".sha256", ContentDigest.SHA_256, writeChecksumFile );
         }
 
     }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha384GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha384GeneratorFactory.java
@@ -31,20 +31,20 @@ public final class Sha384GeneratorFactory
     }
 
     @Override
-    protected Sha384Generator newGenerator( final Transfer transfer )
+    protected Sha384Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile )
         throws IOException
     {
-        return new Sha384Generator( transfer );
+        return new Sha384Generator( transfer, writeChecksumFile );
     }
 
     public static final class Sha384Generator
         extends AbstractChecksumGenerator
     {
 
-        protected Sha384Generator( final Transfer transfer )
+        protected Sha384Generator( final Transfer transfer, final boolean writeChecksumFile )
             throws IOException
         {
-            super( transfer, ".sha384", SHA_384 );
+            super( transfer, ".sha384", SHA_384, writeChecksumFile );
         }
 
     }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha512GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha512GeneratorFactory.java
@@ -31,20 +31,20 @@ public final class Sha512GeneratorFactory
     }
 
     @Override
-    protected Sha512Generator newGenerator( final Transfer transfer )
+    protected Sha512Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile )
         throws IOException
     {
-        return new Sha512Generator( transfer );
+        return new Sha512Generator( transfer, writeChecksumFile );
     }
 
     public static final class Sha512Generator
         extends AbstractChecksumGenerator
     {
 
-        protected Sha512Generator( final Transfer transfer )
+        protected Sha512Generator( final Transfer transfer, final boolean writeChecksumFile )
             throws IOException
         {
-            super( transfer, ".sha512", SHA_512 );
+            super( transfer, ".sha512", SHA_512, writeChecksumFile );
         }
 
     }

--- a/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingTransferDecoratorTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingTransferDecoratorTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2013 Red Hat, Inc. (jdcasey@commonjava.org)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,7 @@ import org.apache.commons.io.IOUtils;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.io.ChecksummingTransferDecorator;
 import org.commonjava.maven.galley.io.SpecialPathManagerImpl;
+import org.commonjava.maven.galley.io.checksum.testutil.TestDecoratorAdvisor;
 import org.commonjava.maven.galley.io.checksum.testutil.TestMetadataConsumer;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.SimpleLocation;
@@ -28,29 +29,29 @@ import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
 import org.commonjava.maven.galley.testing.core.ApiFixture;
 import org.hamcrest.CoreMatchers;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
-import java.security.KeyStore;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 
 import static java.lang.Boolean.TRUE;
+import static org.apache.commons.codec.digest.DigestUtils.md5Hex;
 import static org.commonjava.maven.galley.io.ChecksummingTransferDecorator.FORCE_CHECKSUM;
 import static org.commonjava.maven.galley.io.checksum.ContentDigest.MD5;
+import static org.commonjava.maven.galley.io.checksum.testutil.TestDecoratorAdvisor.DO_CHECKSUMS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -61,42 +62,37 @@ public class ChecksummingTransferDecoratorTest
     @Rule
     public TemporaryFolder temp = new TemporaryFolder();
 
-    @Rule
     public ApiFixture fixture = new ApiFixture( temp );
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     private TestMetadataConsumer metadataConsumer = new TestMetadataConsumer();
 
-    @Before
-    public void before()
+    @Test
+    public void forceChecksumOnReadWhenChecksumsAreDisabledForReads()
+            throws Exception
     {
         fixture.setDecorator( new ChecksummingTransferDecorator( Collections.<TransferOperation>emptySet(),
                                                                  new SpecialPathManagerImpl(), false, false,
                                                                  metadataConsumer, new Md5GeneratorFactory() ) );
         fixture.initMissingComponents();
         fixture.getCache().startReporting();
-    }
 
-    @Test
-    public void forceChecksumOnReadWhenChecksumsAreDisabledForReads()
-            throws Exception
-    {
         String path = "my-path.txt";
-        final Transfer txfr = fixture.getCache()
-                                     .getTransfer(
-                                             new ConcreteResource( new SimpleLocation( "test:uri" ), path ) );
+        final Transfer txfr =
+                fixture.getCache().getTransfer( new ConcreteResource( new SimpleLocation( "test:uri" ), path ) );
 
-        File f = new File( temp.getRoot(), "cache/test:uri");
+        File f = new File( temp.getRoot(), "cache/test:uri" );
         f = new File( f, path );
 
-        byte[] data = "This is a test with a bunch of data and some other stuff, in a big box sealed with chewing gum".getBytes();
+        byte[] data =
+                "This is a test with a bunch of data and some other stuff, in a big box sealed with chewing gum".getBytes();
 
-        FileUtils.writeByteArrayToFile(f, data );
+        FileUtils.writeByteArrayToFile( f, data );
 
         logger.info( "Opening transfer input stream" );
         EventMetadata forceEventMetadata = new EventMetadata().set( FORCE_CHECKSUM, TRUE );
-        try(InputStream stream = txfr.openInputStream( false, forceEventMetadata ))
+        try (InputStream stream = txfr.openInputStream( false, forceEventMetadata ))
         {
             logger.info( "Reading stream" );
             byte[] resultData = IOUtils.toByteArray( stream );
@@ -111,16 +107,6 @@ public class ChecksummingTransferDecoratorTest
         final byte[] digest = md.digest();
         final String digestHex = Hex.encodeHexString( digest );
 
-        logger.debug( "Verifying .md5 file" );
-        final Transfer md5Txfr = txfr.getSiblingMeta( ".md5" );
-        String resultHex = null;
-        try(InputStream in = md5Txfr.openInputStream())
-        {
-            resultHex = IOUtils.toString( in );
-        }
-
-        assertThat( resultHex, equalTo( digestHex ) );
-
         logger.debug( "Verifying MD5 in metadata consumer" );
         TransferMetadata metadata = metadataConsumer.getMetadata( txfr );
         assertThat( metadata, notNullValue() );
@@ -134,21 +120,27 @@ public class ChecksummingTransferDecoratorTest
     public void noChecksumOnReadWhenChecksumsAreDisabledForReads()
             throws Exception
     {
-        String path = "my-path.txt";
-        final Transfer txfr = fixture.getCache()
-                                     .getTransfer(
-                                             new ConcreteResource( new SimpleLocation( "test:uri" ), path ) );
+        fixture.setDecorator( new ChecksummingTransferDecorator( Collections.<TransferOperation>emptySet(),
+                                                                 new SpecialPathManagerImpl(), false, false,
+                                                                 metadataConsumer, new Md5GeneratorFactory() ) );
+        fixture.initMissingComponents();
+        fixture.getCache().startReporting();
 
-        File f = new File( temp.getRoot(), "cache/test:uri");
+        String path = "my-path.txt";
+        final Transfer txfr =
+                fixture.getCache().getTransfer( new ConcreteResource( new SimpleLocation( "test:uri" ), path ) );
+
+        File f = new File( temp.getRoot(), "cache/test:uri" );
         f = new File( f, path );
 
-        byte[] data = "This is a test with a bunch of data and some other stuff, in a big box sealed with chewing gum".getBytes();
+        byte[] data =
+                "This is a test with a bunch of data and some other stuff, in a big box sealed with chewing gum".getBytes();
 
-        FileUtils.writeByteArrayToFile(f, data );
+        FileUtils.writeByteArrayToFile( f, data );
 
         logger.info( "Opening transfer input stream" );
         EventMetadata forceEventMetadata = new EventMetadata();
-        try(InputStream stream = txfr.openInputStream( false, forceEventMetadata ))
+        try (InputStream stream = txfr.openInputStream( false, forceEventMetadata ))
         {
             logger.info( "Reading stream" );
             byte[] resultData = IOUtils.toByteArray( stream );
@@ -165,6 +157,89 @@ public class ChecksummingTransferDecoratorTest
         logger.debug( "Verifying MD5 in metadata consumer is missing" );
         TransferMetadata metadata = metadataConsumer.getMetadata( txfr );
         assertThat( metadata, nullValue() );
+    }
+
+    @Test
+    public void customChecksumReaderFilter()
+            throws Exception
+    {
+        String path = "my-path.txt";
+
+        fixture.setDecorator(
+                new ChecksummingTransferDecorator( new TestDecoratorAdvisor(), new DisabledChecksummingDecoratorAdvisor(),
+                                                   new SpecialPathManagerImpl(), metadataConsumer,
+                                                   new Md5GeneratorFactory() ) );
+        fixture.initMissingComponents();
+        fixture.getCache().startReporting();
+
+        final Transfer txfr =
+                fixture.getCache().getTransfer( new ConcreteResource( new SimpleLocation( "test:uri" ), path ) );
+
+        File f = new File( temp.getRoot(), "cache/test:uri" );
+        f = new File( f, path );
+
+        byte[] data =
+                "This is a test with a bunch of data and some other stuff, in a big box sealed with chewing gum".getBytes();
+
+        FileUtils.writeByteArrayToFile( f, data );
+
+        EventMetadata em = new EventMetadata();
+
+        logger.debug( "Reading stream with EventMetadata advice: {}", em.get( DO_CHECKSUMS ) );
+        assertRead( txfr, data, em, false, false );
+
+        em = new EventMetadata().set( DO_CHECKSUMS,
+                                      ChecksummingDecoratorAdvisor.ChecksumAdvice.CALCULATE_NO_WRITE );
+
+        logger.debug( "Reading stream with EventMetadata advice: {}", em.get( DO_CHECKSUMS ) );
+        assertRead( txfr, data, em, false, true );
+
+        logger.debug( "Removing checksum metadata from consumer" );
+        metadataConsumer.removeMetadata( txfr );
+
+        em = new EventMetadata().set( DO_CHECKSUMS,
+                                      ChecksummingDecoratorAdvisor.ChecksumAdvice.CALCULATE_AND_WRITE );
+
+        logger.debug( "Reading stream with EventMetadata advice: {}", em.get( DO_CHECKSUMS ) );
+        assertRead( txfr, data, em, true, true );
+
+    }
+
+    private void assertRead( final Transfer txfr, final byte[] data, final EventMetadata em,
+                             final boolean checksumFileExists, final boolean metadataConsumerContains )
+            throws IOException
+    {
+        try (InputStream stream = txfr.openInputStream( false, em ))
+        {
+            logger.info( "Reading stream" );
+            byte[] resultData = IOUtils.toByteArray( stream );
+
+            logger.debug( "Result is {} bytes", resultData.length );
+
+            assertThat( Arrays.equals( resultData, data ), equalTo( true ) );
+        }
+
+        logger.debug( "Verifying .md5 file is {}", checksumFileExists ? "available" : "misssing" );
+        final Transfer md5Txfr = txfr.getSiblingMeta( ".md5" );
+        assertThat( md5Txfr.exists(), equalTo( checksumFileExists ) );
+
+        TransferMetadata metadata = metadataConsumer.getMetadata( txfr );
+        if ( metadataConsumerContains )
+        {
+            logger.debug( "Verifying MD5 in metadata consumer is available" );
+            assertThat( metadata, notNullValue() );
+
+            String actualMd5 = metadata.getDigests().get( MD5 );
+            String expectedMd5 = md5Hex( data );
+            logger.debug( "Verifying actual MD5 content: '{}' vs. expected: '{}'", actualMd5, expectedMd5 );
+
+            assertThat( actualMd5, equalTo( expectedMd5 ) );
+        }
+        else
+        {
+            logger.debug( "Verifying MD5 in metadata consumer is missing" );
+            assertThat( metadata, nullValue() );
+        }
     }
 
 }

--- a/core/src/test/java/org/commonjava/maven/galley/io/checksum/Md5GeneratorFactoryTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/io/checksum/Md5GeneratorFactoryTest.java
@@ -63,7 +63,7 @@ public class Md5GeneratorFactoryTest
 
         final Md5GeneratorFactory factory = new Md5GeneratorFactory();
 
-        final Md5Generator generator = factory.newGenerator( txfr );
+        final Md5Generator generator = factory.newGenerator( txfr, true );
         generator.update( data );
         generator.write();
 

--- a/core/src/test/java/org/commonjava/maven/galley/io/checksum/testutil/TestDecoratorAdvisor.java
+++ b/core/src/test/java/org/commonjava/maven/galley/io/checksum/testutil/TestDecoratorAdvisor.java
@@ -1,0 +1,25 @@
+package org.commonjava.maven.galley.io.checksum.testutil;
+
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.io.checksum.ChecksummingDecoratorAdvisor;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+
+import static org.commonjava.maven.galley.io.checksum.ChecksummingDecoratorAdvisor.ChecksumAdvice.NO_DECORATE;
+
+/**
+ * Created by jdcasey on 5/5/17.
+ */
+public class TestDecoratorAdvisor
+        implements ChecksummingDecoratorAdvisor
+{
+    public static final String DO_CHECKSUMS = "doChecksums";
+
+    @Override
+    public ChecksumAdvice getDecorationAdvice( final Transfer transfer, final TransferOperation operation,
+                                               final EventMetadata eventMetadata )
+    {
+        ChecksumAdvice advice = (ChecksumAdvice) eventMetadata.get( DO_CHECKSUMS );
+        return advice == null ? NO_DECORATE : advice;
+    }
+}

--- a/core/src/test/java/org/commonjava/maven/galley/io/checksum/testutil/TestMetadataConsumer.java
+++ b/core/src/test/java/org/commonjava/maven/galley/io/checksum/testutil/TestMetadataConsumer.java
@@ -18,6 +18,8 @@ package org.commonjava.maven.galley.io.checksum.testutil;
 import org.commonjava.maven.galley.io.checksum.TransferMetadata;
 import org.commonjava.maven.galley.io.checksum.TransferMetadataConsumer;
 import org.commonjava.maven.galley.model.Transfer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,7 +34,10 @@ public class TestMetadataConsumer
 
     public TransferMetadata getMetadata( Transfer transfer )
     {
-        return metadata.get( transfer );
+        TransferMetadata transferMetadata = metadata.get( transfer );
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.info( "Returning metadata: {} for transfer: {}", transferMetadata, transfer );
+        return transferMetadata;
     }
 
     @Override
@@ -44,6 +49,8 @@ public class TestMetadataConsumer
     @Override
     public synchronized void addMetadata( final Transfer transfer, final TransferMetadata transferData )
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.info( "Adding metadata: {} for transfer: {}", transferData, transfer );
         metadata.put( transfer, transferData );
     }
 

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -18,11 +18,12 @@
     </encoder>
   </appender>
 
-  <logger name="chapters.configuration" level="INFO"/>
+  <logger name="org.commonjava.maven.galley.io.ChecksummingTransferDecorator" level="TRACE"/>
+  <logger name="org.commonjava.maven.galley.io.checksum" level="TRACE"/>
 
   <!-- Strictly speaking, the level attribute is not necessary since -->
   <!-- the level of the root level is set to DEBUG by default.       -->
-  <root level="DEBUG">          
+  <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>  
   


### PR DESCRIPTION
There isn't enough control over when checksums get calculated, and the controls over when checksum files
get written are confusing. The result is that Indy is calculating checksums on literally everything when
it only needs to do so in specific cases when Folo tracking is enabled.

This change provides a new interface, ChecksummingDecoratorAdvisor, which allows Indy to inject specific
logic about when checksums should be calculated, stored, or skipped. The old constructor is still present
but deprecated, and the old ctor params are used to create two internal advisors that replicate the old
behavior. ChecksummingDecoratorAdvisor returns ChecksumAdvice, which is an enum that has three values:
NO_DEORATE, CALCULATE_NO_WRITE, and CALCULATE_AND_WRITE. This covers the three branches of the logic
in the decorator now. All AbstractChecksumGenerator implementations now accept a writeChecksumFiles
constructor parameter, to control whether the retrieve and lock Transfers corresponding to their
checksum file type.

The change also provides DisabledChecksummingDecoratorAdvisor, which can be used to completely disable
non-forced checksumming for reads or writes, if that's appropriate.