### PR TITLE
Resolve npm storage with path mapping.

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/model/Transfer.java
+++ b/api/src/main/java/org/commonjava/maven/galley/model/Transfer.java
@@ -43,7 +43,7 @@ public class Transfer
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
-    private final ConcreteResource resource;
+    private ConcreteResource resource;
 
     private final CacheProvider provider;
 
@@ -509,4 +509,8 @@ public class Transfer
         return decorator;
     }
 
+    public void setResource( ConcreteResource resource )
+    {
+        this.resource = resource;
+    }
 }

--- a/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
+++ b/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
@@ -32,6 +32,8 @@ public interface CacheProvider
 
     String SUFFIX_TO_WRITE = ".to-write";
 
+    String STORAGE_PATH = "storage-path";
+
     Set<String> HIDDEN_SUFFIXES = Collections.unmodifiableSet( new HashSet<String>()
     {
         {

--- a/api/src/main/java/org/commonjava/maven/galley/util/PathUtils.java
+++ b/api/src/main/java/org/commonjava/maven/galley/util/PathUtils.java
@@ -15,6 +15,10 @@
  */
 package org.commonjava.maven.galley.util;
 
+import org.commonjava.maven.galley.event.EventMetadata;
+
+import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORAGE_PATH;
+
 public final class PathUtils
 {
 
@@ -106,6 +110,12 @@ public final class PathUtils
         }
 
         return sb.toString();
+    }
+
+    public static String storagePath ( final String path, final EventMetadata eventMetadata )
+    {
+        String storage = (String) eventMetadata.get( STORAGE_PATH );
+        return storage == null ? path : normalize( storage );
     }
 
 }

--- a/api/src/main/java/org/commonjava/maven/galley/util/ResourceUtils.java
+++ b/api/src/main/java/org/commonjava/maven/galley/util/ResourceUtils.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (yma@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.galley.util;
+
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.model.ConcreteResource;
+
+public final class ResourceUtils
+{
+    public ResourceUtils()
+    {
+    }
+
+    public static ConcreteResource storageResource ( final ConcreteResource resource, final EventMetadata eventMetadata)
+    {
+        String storagePath = PathUtils.storagePath( resource.getPath(), eventMetadata );
+        return new ConcreteResource( resource.getLocation(), storagePath );
+    }
+}

--- a/core/src/main/java/org/commonjava/maven/galley/internal/TransferManagerImpl.java
+++ b/core/src/main/java/org/commonjava/maven/galley/internal/TransferManagerImpl.java
@@ -46,6 +46,7 @@ import org.commonjava.maven.galley.spi.io.TransferDecorator;
 import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
 import org.commonjava.maven.galley.spi.transport.Transport;
 import org.commonjava.maven.galley.spi.transport.TransportManager;
+import org.commonjava.maven.galley.util.ResourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,6 +74,7 @@ import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.apache.commons.io.IOUtils.copy;
 import static org.apache.commons.lang.StringUtils.join;
 import static org.commonjava.maven.galley.model.Transfer.DELETE_CONTENT_LOG;
+import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORAGE_PATH;
 import static org.commonjava.maven.galley.util.LocationUtils.getTimeoutSeconds;
 
 @ApplicationScoped
@@ -342,7 +344,7 @@ public class TransferManagerImpl
                 if ( remoteResult != null )
                 {
                     String[] remoteListing = remoteResult.getListing();
-                    if ( remoteListing != null )
+                    if ( remoteListing != null && remoteListing.length > 0 )
                     {
                         final TransferDecorator decorator = cachedListing.getDecorator();
                         if ( decorator != null )
@@ -363,7 +365,7 @@ public class TransferManagerImpl
                         }
                     }
 
-                    if ( remoteListing != null )
+                    if ( remoteListing != null && remoteListing.length > 0  )
                     {
                         if ( transport.allowsCaching() )
                         {
@@ -604,9 +606,13 @@ public class TransferManagerImpl
     }
 
     @Override
-    public Transfer store( final ConcreteResource resource , final InputStream stream , final EventMetadata eventMetadata  )
+    public Transfer store( ConcreteResource resource , final InputStream stream , final EventMetadata eventMetadata  )
         throws TransferException
     {
+        if ( eventMetadata.get( STORAGE_PATH ) != null )
+        {
+            resource = ResourceUtils.storageResource( resource, eventMetadata );
+        }
         SpecialPathInfo specialPathInfo = specialPathManager.getSpecialPathInfo( resource, eventMetadata.getPackageType() );
         if ( !resource.allowsStoring() || ( specialPathInfo != null && !specialPathInfo.isStorable() ) )
         {

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
@@ -17,6 +17,7 @@ package org.commonjava.maven.galley.transport.htcli.internal;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.apache.commons.io.IOUtils.copy;
+import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORAGE_PATH;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,6 +37,7 @@ import org.commonjava.maven.galley.transport.htcli.model.HttpLocation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.commonjava.maven.galley.transport.htcli.util.HttpUtil;
+import org.commonjava.maven.galley.util.ResourceUtils;
 
 public final class HttpDownload
     extends AbstractHttpJob
@@ -117,6 +119,10 @@ public final class HttpDownload
     @Override
     public Transfer getTransfer()
     {
+        if ( eventMetadata.get( STORAGE_PATH ) != null )
+        {
+            target.setResource( ResourceUtils.storageResource( target.getResource(), eventMetadata ) );
+        }
         return target;
     }
 


### PR DESCRIPTION
  looking up EventMetadata’s new attribute: CacheProvider.STORAGE_PATH
  when coming across any npm request in Transer layer,
  ResourceUtils.storagePath, PathUtils.storagePath provide the mapping path
  (fetch from EventMetadata key: STORAGE_PATH) for a ConcreteResource’s path