### PR TITLE
Flush content buffer in ChecksummingOutputStream before calculate checksum

### DIFF
--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStream.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStream.java
@@ -66,6 +66,7 @@ public final class ChecksummingOutputStream
         try
         {
             logger.trace( "START CLOSE: {}", transfer );
+            super.flush();
             logger.trace( "Wrote: {} (size: {}) in: {}. Now, writing checksums.", transfer.getPath(), size, transfer.getLocation() );
             Map<ContentDigest, String> hexDigests = new HashMap<>();
             for ( final AbstractChecksumGenerator checksum : checksums )


### PR DESCRIPTION
@jdcasey When ChecksummingOutputStream close is called, it will calculate checksum before calling the super.close(). There might still be some bytes remained in its buffer and not written to disk. Then metadataConsumer calculates the checksum with incomplete content, and store it in the cache. I guess this is really a possible problem that can cause checksum mismatch. I have not a test case to verify it yet, but please let me know what you think. 