### PR TITLE
[NPM] avoid some package.json redirect path empty errors (visit by the listing), especially for the group

### DIFF
--- a/core/src/main/java/org/commonjava/maven/galley/internal/TransferManagerImpl.java
+++ b/core/src/main/java/org/commonjava/maven/galley/internal/TransferManagerImpl.java
@@ -313,6 +313,13 @@ public class TransferManagerImpl
                         {
                             for ( String fname : fnames )
                             {
+                                // npm will only show the project as a file path no matter it's a real file or path,
+                                // this will avoid some package.json redirect path empty errors, especially for the group.
+                                if ( metadata.get( STORAGE_PATH ) != null )
+                                {
+                                    filenames.add( fname );
+                                    continue;
+                                }
                                 final ConcreteResource child = resource.getChild( fname );
                                 final Transfer childRef = getCacheReference( child );
                                 if ( childRef.isFile() )


### PR DESCRIPTION
such as for the conent listing:
if not fix this, hosted will show: jquery/
remote will show: jquery
group will show: jquery/

while if someone visits remote or group content (include a remote at least) as jquery/, will report some empty error. This will also effect the group merging result if some one visit jquery/ before jquery, this fix will prevent it from the listing visit side.

after fix this, all the types of repo will show the contents like 'jquery' (just like a file).

Acturally, we should do the listing or html page showing like other npm registries in future? they will not show any projects on the index listing, only the json of some metadatas about the regisitry, while unified metadata json between hosted and remote should be definite, I know this is not a high priority issue, just found this when doing the manual tests.