### PR TITLE
Throw TransferLocationException for wider range of 4xx / 5xx status codes

### DIFF
--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/AbstractHttpJob.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/AbstractHttpJob.java
@@ -109,7 +109,13 @@ public abstract class AbstractHttpJob
             final StatusLine line = response.getStatusLine();
             final int sc = line.getStatusCode();
             logger.debug( "{} {} : {}", request.getMethod(), line, url );
-            if ( !successStatuses.contains( sc ) )
+            if ( sc > 399 && sc != 404 && sc != 408 && sc != 502 && sc != 503 && sc != 504 )
+            {
+                throw new TransferLocationException( location,
+                                                     "Server misconfigured or not responding normally: '%s'",
+                                                     line );
+            }
+            else if ( !successStatuses.contains( sc ) )
             {
                 logger.debug( "Detected failure response: " + sc );
                 success = TransferResponseUtils.handleUnsuccessfulResponse( request, response, location, url );
@@ -138,6 +144,10 @@ public abstract class AbstractHttpJob
                                          e.getMessage() );
         }
         catch ( BadGatewayException e )
+        {
+            throw e;
+        }
+        catch ( TransferLocationException e )
         {
             throw e;
         }


### PR DESCRIPTION
Skipping 404 and 502-504, which are temporary problems, Galley's HTTP transfer
jobs should throw TransferLocationException for other 4xx/5xx, since they
represent either a server-side problem that needs to be corrected (not temporary),
or a misconfiguration of the way the Location is setup to talk to the server.

This will trigger Indy (for example) to disable the repository associated with
the error.