### PR TITLE
Some new tests for big file concurrent R/W to test performance

### DIFF
--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderConcurrentIOTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderConcurrentIOTest.java
@@ -16,14 +16,17 @@
 package org.commonjava.maven.galley.cache.infinispan;
 
 import org.apache.commons.io.IOUtils;
+import org.commonjava.maven.galley.cache.iotasks.DeleteTask;
+import org.commonjava.maven.galley.cache.iotasks.ReadTask;
+import org.commonjava.maven.galley.cache.iotasks.WriteTask;
 import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProvider;
 import org.commonjava.maven.galley.cache.testutil.TestFileEventManager;
+import org.commonjava.maven.galley.cache.testutil.TestIOUtils;
 import org.commonjava.maven.galley.cache.testutil.TestTransferDecorator;
 import org.commonjava.maven.galley.io.HashedLocationPathGenerator;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.model.SimpleLocation;
-import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.maven.galley.spi.event.FileEventManager;
 import org.commonjava.maven.galley.spi.io.PathGenerator;
 import org.commonjava.maven.galley.spi.io.TransferDecorator;
@@ -33,18 +36,16 @@ import org.jboss.byteman.contrib.bmunit.BMScript;
 import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -116,15 +117,44 @@ public class FastLocalCacheProviderConcurrentIOTest
     {
         final ConcreteResource resource = createTestResource( "file_read_write.txt" );
         testPool.execute( new WriteTask( provider, content, resource, latch, 1000 ) );
-        final Future<String> readingFuture = testPool.submit((Callable<String>) new ReadTask( provider, content, resource, latch ) );
+        final Future<String> readingFuture =
+                testPool.submit( (Callable<String>) new ReadTask( provider, content, resource, latch ) );
 
-        latchWait( latch );
+        TestIOUtils.latchWait( latch );
 
         final String readingResult = readingFuture.get();
         assertThat( readingResult, equalTo( content ) );
-        assertThat( provider.exists( resource ), equalTo( true ));
-        assertThat( readLocalResource( resource ), equalTo( content ));
-        assertThat( readNFSResource( resource ), equalTo( content ));
+        assertThat( provider.exists( resource ), equalTo( true ) );
+        assertThat( readLocalResource( resource ), equalTo( content ) );
+        assertThat( readNFSResource( resource ), equalTo( content ) );
+    }
+
+    @Test
+    @BMScript( "TryToReadWhileWriting.btm" )
+    @Ignore( "due to low performance of the writing, will ignore this and enable after fixing" )
+    public void testBigFileReadWrite()
+            throws Exception
+    {
+        StringBuilder builder = new StringBuilder();
+        int loop = 1024 * 1024;
+        for ( int i = 0; i < loop; i++ )
+        {
+            builder.append( content );
+        }
+        final String bigContent = builder.toString();
+        System.out.println( "the content size is:" + ( bigContent.length() / 1024 / 1024 ) );
+        final ConcreteResource resource = createTestResource( "file_read_write.txt" );
+        testPool.execute( new WriteTask( provider, bigContent, resource, latch, 1000 ) );
+        final Future<String> readingFuture =
+                testPool.submit( (Callable<String>) new ReadTask( provider, content, resource, latch ) );
+
+        TestIOUtils.latchWait( latch );
+
+        final String readingResult = readingFuture.get();
+        assertThat( readingResult, equalTo( content ) );
+        assertThat( provider.exists( resource ), equalTo( true ) );
+        assertThat( readLocalResource( resource ), equalTo( content ) );
+        assertThat( readNFSResource( resource ), equalTo( content ) );
     }
 
     @Test
@@ -137,7 +167,7 @@ public class FastLocalCacheProviderConcurrentIOTest
         testPool.execute( new WriteTask( provider, diffContent, resource, latch, 1000 ) );
         final Future<String> readingFuture = testPool.submit((Callable<String>) new ReadTask( provider, content, resource, latch ) );
 
-        latchWait( latch );
+        TestIOUtils.latchWait( latch );
 
         final String readingResult = readingFuture.get();
         assertThat( readingResult, equalTo( content ) );
@@ -153,7 +183,7 @@ public class FastLocalCacheProviderConcurrentIOTest
         testPool.execute( new WriteTask( provider, diffContent, resource, latch ) );
         final Future<String> readingFuture = testPool.submit((Callable<String>) new ReadTask( provider, content, resource, latch ) );
 
-        latchWait( latch );
+        TestIOUtils.latchWait( latch );
 
         final String readingResult = readingFuture.get();
         assertThat( readingResult, equalTo( content ) );
@@ -173,7 +203,7 @@ public class FastLocalCacheProviderConcurrentIOTest
         Thread.sleep( 500 );
         final Future<String> readingFuture = testPool.submit((Callable<String>) new ReadTask( provider, content, resource, latch, 500 ) );
 
-        latchWait( latch );
+        TestIOUtils.latchWait( latch );
 
         final String readingResult = readingFuture.get();
         assertThat( readingResult, equalTo( diffContent ) );
@@ -188,7 +218,7 @@ public class FastLocalCacheProviderConcurrentIOTest
         testPool.execute( new WriteTask( provider, content, resource, latch ) );
         final Future<String> readingFuture = testPool.submit((Callable<String>) new ReadTask( provider, content, resource, latch ) );
 
-        latchWait( latch );
+        TestIOUtils.latchWait( latch );
 
         final String readingResult = readingFuture.get();
         assertNull(readingResult);
@@ -241,7 +271,7 @@ public class FastLocalCacheProviderConcurrentIOTest
                      .forEach( i -> testPool.execute( new WriteTask( provider, content, resource, waitLatch ) ) );
         }
 
-        latchWait( waitLatch );
+        TestIOUtils.latchWait( waitLatch );
 
         for ( ConcreteResource resource : resources )
         {
@@ -258,7 +288,7 @@ public class FastLocalCacheProviderConcurrentIOTest
         final Future<String> readingFuture1 = testPool.submit((Callable<String>) new ReadTask( provider, content, resource, latch ) );
         final Future<String> readingFuture2 = testPool.submit((Callable<String>) new ReadTask( provider, content, resource, latch ) );
 
-        latchWait( latch );
+        TestIOUtils.latchWait( latch );
 
         final String readingResult1 = readingFuture1.get();
         assertThat( readingResult1, equalTo( content ) );
@@ -277,7 +307,7 @@ public class FastLocalCacheProviderConcurrentIOTest
                 testPool.submit( (Callable<Boolean>) new DeleteTask( provider, content, resource, latch ) );
         final Future<String> readingFuture = testPool.submit((Callable<String>) new ReadTask( provider, content, resource, latch ) );
 
-        latchWait( latch );
+        TestIOUtils.latchWait( latch );
 
         final Boolean deleted = deleteFuture.get();
         final String readingResult = readingFuture.get();
@@ -297,7 +327,7 @@ public class FastLocalCacheProviderConcurrentIOTest
                 testPool.submit( (Callable<Boolean>) new DeleteTask( provider, content, resource, latch ) );
         final Future<String> readingFuture = testPool.submit((Callable<String>) new ReadTask( provider, content, resource, latch, 1000 ) );
 
-        latchWait( latch );
+        TestIOUtils.latchWait( latch );
 
         final Boolean deleted = deleteFuture.get();
         final String readingResult = readingFuture.get();
@@ -317,7 +347,7 @@ public class FastLocalCacheProviderConcurrentIOTest
                 testPool.submit( (Callable<Boolean>) new DeleteTask( provider, content, resource, latch ) );
         final Future<String> readingFuture = testPool.submit((Callable<String>) new ReadTask( provider, content, resource, latch, 1000 ) );
 
-        latchWait( latch );
+        TestIOUtils.latchWait( latch );
 
         final Boolean deleted = deleteFuture.get();
         final String readingResult = readingFuture.get();
@@ -337,7 +367,7 @@ public class FastLocalCacheProviderConcurrentIOTest
                 testPool.submit( (Callable<Boolean>) new DeleteTask( provider, content, resource, latch ) );
         final Future<String> readingFuture = testPool.submit((Callable<String>) new ReadTask( provider, content, resource, latch ) );
 
-        latchWait( latch );
+        TestIOUtils.latchWait( latch );
 
         final Boolean deleted = deleteFuture.get();
         final String readingResult = readingFuture.get();
@@ -356,7 +386,7 @@ public class FastLocalCacheProviderConcurrentIOTest
                 testPool.submit( (Callable<Boolean>) new DeleteTask( provider, content, resource, latch ) );
         testPool.execute( new WriteTask( provider, content, resource, latch ) );
 
-        latchWait( latch );
+        TestIOUtils.latchWait( latch );
 
         final Boolean deleted = deleteFuture.get();
         assertThat( deleted, equalTo( true ) );
@@ -373,7 +403,7 @@ public class FastLocalCacheProviderConcurrentIOTest
                 testPool.submit( (Callable<Boolean>) new DeleteTask( provider, content, resource, latch ) );
         testPool.execute( new WriteTask( provider, content, resource, latch, 1000 ) );
 
-        latchWait( latch );
+        TestIOUtils.latchWait( latch );
 
         final Boolean deleted = deleteFuture.get();
         assertThat( deleted, equalTo( false ) );
@@ -391,7 +421,7 @@ public class FastLocalCacheProviderConcurrentIOTest
                 testPool.submit( (Callable<Boolean>) new DeleteTask( provider, content, resource, latch ) );
         testPool.execute( new WriteTask( provider, content, resource, latch ) );
 
-        latchWait( latch );
+        TestIOUtils.latchWait( latch );
 
         final Boolean deleted = deleteFuture.get();
         assertThat( deleted, equalTo( true ) );
@@ -409,27 +439,13 @@ public class FastLocalCacheProviderConcurrentIOTest
         final Future<Boolean> deleteFurture2 =
                 testPool.submit( (Callable<Boolean>) new DeleteTask( provider, content, resource, latch ) );
 
-        latchWait( latch );
+        TestIOUtils.latchWait( latch );
 
         final Boolean deleted1 = deleteFurture1.get();
         final Boolean deleted2 = deleteFurture2.get();
         assertThat( deleted1 && deleted2, equalTo( false ) );
         assertThat( deleted1 || deleted2, equalTo( true ) );
         assertThat( provider.exists( resource ), equalTo( false ) );
-    }
-
-
-
-    private void latchWait( CountDownLatch latch )
-    {
-        try
-        {
-            latch.await();
-        }
-        catch ( InterruptedException e )
-        {
-            System.out.println( "Threads await Exception." );
-        }
     }
 
     private String createNFSBaseDir( String tempBaseDir )
@@ -473,33 +489,13 @@ public class FastLocalCacheProviderConcurrentIOTest
     private String readLocalResource( ConcreteResource resource )
             throws IOException
     {
-        return readFromStream( plProvider.openInputStream( resource ) );
+        return TestIOUtils.readFromStream( plProvider.openInputStream( resource ) );
     }
 
     private String readNFSResource(ConcreteResource resource ) throws IOException{
-        return readFromStream( new FileInputStream( provider.getNFSDetachedFile( resource ) ) );
+        return TestIOUtils.readFromStream( new FileInputStream( provider.getNFSDetachedFile( resource ) ) );
     }
 
-    private String readFromStream(InputStream in) throws IOException{
-        if ( in == null )
-        {
-            System.out.println( "Can not read content as the input stream is null." );
-            return null;
-        }
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        int read;
-        final byte[] buf = new byte[512];
-        while ( ( read = in.read( buf ) ) > -1 )
-        {
-            baos.write( buf, 0, read );
-        }
-
-        String readingResult = new String( baos.toByteArray(), "UTF-8" );
-        baos.close();
-        in.close();
-
-        return readingResult;
-    }
 
     private ConcreteResource createTestResource( String fname )
     {
@@ -512,190 +508,4 @@ public class FastLocalCacheProviderConcurrentIOTest
         return new ConcreteResource( loc, String.format( "%s/%s", folder, fname ) );
     }
 
-    private abstract class CacheProviderWorkingTask
-            implements Runnable
-    {
-        protected CacheProvider provider;
-
-        protected String content;
-
-        protected ConcreteResource resource;
-
-        protected CountDownLatch controlLatch;
-
-        protected long waiting;
-
-        protected CacheProviderWorkingTask( CacheProvider provider, String content, ConcreteResource resource,
-                                            CountDownLatch controlLatch, long waiting )
-        {
-            this.provider = provider;
-            this.content = content;
-            this.resource = resource;
-            this.controlLatch = controlLatch;
-            this.waiting = waiting;
-        }
-    }
-
-    private final class WriteTask
-            extends CacheProviderWorkingTask
-    {
-        public WriteTask( CacheProvider provider, String content, ConcreteResource resource,
-                          CountDownLatch controlLatch, long waiting )
-        {
-            super( provider, content, resource, controlLatch, waiting );
-        }
-
-        public WriteTask( CacheProvider provider, String content, ConcreteResource resource,
-                          CountDownLatch controlLatch )
-        {
-            super( provider, content, resource, controlLatch, -1 );
-        }
-
-        @Override
-        public void run()
-        {
-            try
-            {
-                final OutputStream out = provider.openOutputStream( resource );
-                final ByteArrayInputStream bais = new ByteArrayInputStream( content.getBytes() );
-                int read = -1;
-                final byte[] buf = new byte[512];
-                System.out.println(
-                        String.format( "<<<WriteTask>>> start to write to the resource with outputStream %s",
-                                       out.getClass().getName() ) );
-                while ( ( read = bais.read( buf ) ) > -1 )
-                {
-                    if ( waiting > 0 )
-                    {
-                        Thread.sleep( waiting );
-                    }
-                    out.write( buf, 0, read );
-                }
-                out.close();
-                System.out.println(
-                        String.format( "<<<WriteTask>>> writing to the resource done with outputStream %s",
-                                       out.getClass().getName() ) );
-                controlLatch.countDown();
-            }
-            catch ( Exception e )
-            {
-                System.out.println( "Write Task Runtime Exception." );
-                e.printStackTrace();
-            }
-        }
-    }
-
-    private final class ReadTask
-            extends CacheProviderWorkingTask implements Callable<String>
-    {
-        private String readingResult;
-
-        public ReadTask( CacheProvider provider, String content, ConcreteResource resource,
-                         CountDownLatch controlLatch )
-        {
-            super( provider, content, resource, controlLatch, -1 );
-        }
-
-        public ReadTask( CacheProvider provider, String content, ConcreteResource resource, CountDownLatch controlLatch,
-                         long waiting )
-        {
-            super( provider, content, resource, controlLatch, waiting );
-        }
-
-        @Override
-        public void run()
-        {
-            try
-            {
-                final InputStream in = provider.openInputStream( resource );
-                if ( in == null )
-                {
-                    System.out.println( "Can not read content as the input stream is null." );
-                    controlLatch.countDown();
-                    return;
-                }
-                final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                int read = -1;
-                final byte[] buf = new byte[512];
-                System.out.println(
-                        String.format( "<<<ReadTask>>> will start to read from the resource with inputStream %s",
-                                       in.getClass().getName() ) );
-                while ( ( read = in.read( buf ) ) > -1 )
-                {
-                    if ( waiting > 0 )
-                    {
-                        Thread.sleep( waiting );
-                    }
-                    baos.write( buf, 0, read );
-                }
-                baos.close();
-                in.close();
-                System.out.println(
-                        String.format( "<<<ReadTask>>> reading from the resource done with inputStream %s",
-                                       in.getClass().getName() ) );
-                readingResult = new String( baos.toByteArray(), "UTF-8" );
-                controlLatch.countDown();
-            }
-            catch ( Exception e )
-            {
-                System.out.println( "Read Task Runtime Exception." );
-                e.printStackTrace();
-            }
-        }
-
-        @Override
-        public String call(){
-            this.run();
-            return readingResult;
-        }
-    }
-
-    private final class DeleteTask
-            extends CacheProviderWorkingTask
-            implements Callable<Boolean>
-    {
-        private Boolean callResult;
-
-        public DeleteTask( CacheProvider provider, String content, ConcreteResource resource,
-                           CountDownLatch controlLatch )
-        {
-            super( provider, content, resource, controlLatch, -1 );
-        }
-
-        public DeleteTask( CacheProvider provider, String content, ConcreteResource resource,
-                           CountDownLatch controlLatch, long waiting )
-        {
-            super( provider, content, resource, controlLatch, waiting );
-        }
-
-        @Override
-        public void run()
-        {
-            try
-            {
-                if ( waiting > 0 )
-                {
-                    Thread.sleep( waiting );
-                }
-                System.out.println("<<<DeleteTask>>> start to delete resource");
-                callResult = provider.delete( resource );
-            }
-            catch ( Exception e )
-            {
-                System.out.println( "Delete Task Runtime Exception." );
-                e.printStackTrace();
-            }
-            finally
-            {
-                controlLatch.countDown();
-            }
-        }
-
-        @Override
-        public Boolean call()
-        {
-            this.run();
-            return callResult;
-        }
-    }
 }

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderIOTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderIOTest.java
@@ -15,8 +15,6 @@
  */
 package org.commonjava.maven.galley.cache.infinispan;
 
-import org.apache.commons.io.IOUtils;
-import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProvider;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.model.SimpleLocation;
@@ -26,13 +24,10 @@ import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 

--- a/caches/partyline/src/test/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProviderConcurrentIOTest.java
+++ b/caches/partyline/src/test/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProviderConcurrentIOTest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.galley.cache.partyline;
+
+import org.commonjava.maven.galley.cache.iotasks.ReadTask;
+import org.commonjava.maven.galley.cache.iotasks.WriteTask;
+import org.commonjava.maven.galley.cache.testutil.TestFileEventManager;
+import org.commonjava.maven.galley.cache.testutil.TestIOUtils;
+import org.commonjava.maven.galley.cache.testutil.TestTransferDecorator;
+import org.commonjava.maven.galley.io.HashedLocationPathGenerator;
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.model.SimpleLocation;
+import org.commonjava.maven.galley.spi.event.FileEventManager;
+import org.commonjava.maven.galley.spi.io.PathGenerator;
+import org.commonjava.maven.galley.spi.io.TransferDecorator;
+import org.jboss.byteman.contrib.bmunit.BMScript;
+import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import java.io.FileInputStream;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+@RunWith( org.jboss.byteman.contrib.bmunit.BMUnitRunner.class )
+@BMUnitConfig( loadDirectory = "target/test-classes/bmunit", debug = true )
+public class PartyLineCacheProviderConcurrentIOTest
+{
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    private final String content = "This is a bmunit test";
+
+    private final String diffContent = "This is different from content";
+
+    private final CountDownLatch latch = new CountDownLatch( 2 );
+
+    private PartyLineCacheProvider provider;
+
+    private final PathGenerator pathgen = new HashedLocationPathGenerator();
+
+    private final FileEventManager events = new TestFileEventManager();
+
+    private final TransferDecorator decorator = new TestTransferDecorator();
+
+    private PartyLineCacheProvider plProvider;
+
+    private final ExecutorService executor = Executors.newFixedThreadPool( 4 );
+
+    private final ExecutorService testPool = Executors.newFixedThreadPool( 2 );
+
+    @Before
+    public void setup()
+            throws Exception
+    {
+        provider = new PartyLineCacheProvider( temp.newFolder(), pathgen, events, decorator );
+
+    }
+
+    @Test
+    @BMScript( "TryToReadWhileWriting.btm" )
+    public void testReadWrite()
+            throws Exception
+    {
+        final ConcreteResource resource = createTestResource( "file_read_write.txt" );
+        testPool.execute( new WriteTask( provider, content, resource, latch, 1000 ) );
+        final Future<String> readingFuture =
+                testPool.submit( (Callable<String>) new ReadTask( provider, content, resource, latch ) );
+
+        TestIOUtils.latchWait( latch );
+
+        final String readingResult = readingFuture.get();
+        assertThat( readingResult, equalTo( content ) );
+        assertThat( provider.exists( resource ), equalTo( true ) );
+        assertThat( TestIOUtils.readFromStream( new FileInputStream( provider.getDetachedFile( resource ) ) ), equalTo( content ) );
+    }
+
+    @Test
+    @BMScript( "TryToReadWhileWriting.btm" )
+    @Ignore
+    public void testBigFileReadWrite()
+            throws Exception
+    {
+        StringBuilder builder = new StringBuilder();
+        int loop = 1024;
+        for ( int i = 0; i < loop; i++ )
+        {
+            builder.append( content );
+        }
+        final String bigContent = builder.toString();
+        System.out.println( String.format( "the content size is: %sk", ( bigContent.length() / 1024 ) + "" ) );
+
+        final ConcreteResource resource = createTestResource( "file_read_write_bigfile.txt" );
+        testPool.execute( new WriteTask( provider, bigContent, resource, latch, 1000 ) );
+        final Future<String> readingFuture =
+                testPool.submit( (Callable<String>) new ReadTask( provider, content, resource, latch ) );
+
+        TestIOUtils.latchWait( latch );
+
+        final String readingResult = readingFuture.get();
+        assertThat( readingResult, equalTo( bigContent ) );
+        assertThat( provider.exists( resource ), equalTo( true ) );
+        assertThat( TestIOUtils.readFromStream( new FileInputStream( provider.getDetachedFile( resource ) ) ),
+                    equalTo( bigContent ) );
+    }
+
+    private ConcreteResource createTestResource( String fname )
+    {
+        return createTestResource( fname, "/path/to/my" );
+    }
+
+    private ConcreteResource createTestResource( String fname, String folder )
+    {
+        final Location loc = new SimpleLocation( "http://foo.com" );
+        return new ConcreteResource( loc, String.format( "%s/%s", folder, fname ) );
+    }
+
+}

--- a/caches/partyline/src/test/resources/bmunit/TryToReadWhileWriting.btm
+++ b/caches/partyline/src/test/resources/bmunit/TryToReadWhileWriting.btm
@@ -1,0 +1,21 @@
+RULE try to openInputStream
+CLASS PartyLineCacheProvider
+METHOD openInputStream
+AT ENTRY
+IF TRUE
+DO
+    debug("<<<wait for service enter OutputStream");
+    waitFor("service OutputStream");
+    debug("<<<proceed with openInputStream")
+ENDRULE
+
+RULE service OutputStream
+CLASS PartyLineCacheProvider
+METHOD openOutputStream
+AT EXIT
+IF TRUE
+DO
+    debug("<<<signalling try to openInputStream");
+    signalWake("service OutputStream", true);
+    debug("<<<signalled try ot openInputStream")
+ENDRULE

--- a/caches/pom.xml
+++ b/caches/pom.xml
@@ -41,5 +41,25 @@
       <groupId>org.commonjava.maven.galley</groupId>
       <artifactId>galley-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman-submit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman-install</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman-bmunit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun</groupId>
+      <artifactId>tools</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/caches/tck/src/main/java/org/commonjava/maven/galley/cache/iotasks/CacheProviderWorkingTask.java
+++ b/caches/tck/src/main/java/org/commonjava/maven/galley/cache/iotasks/CacheProviderWorkingTask.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.galley.cache.iotasks;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
+
+public abstract class CacheProviderWorkingTask
+        implements Runnable
+{
+    protected CacheProvider provider;
+
+    protected String content;
+
+    protected ConcreteResource resource;
+
+    protected CountDownLatch controlLatch;
+
+    protected long waiting;
+
+    protected CacheProviderWorkingTask( CacheProvider provider, String content, ConcreteResource resource,
+                                        CountDownLatch controlLatch, long waiting )
+    {
+        this.provider = provider;
+        this.content = content;
+        this.resource = resource;
+        this.controlLatch = controlLatch;
+        this.waiting = waiting;
+    }
+}

--- a/caches/tck/src/main/java/org/commonjava/maven/galley/cache/iotasks/DeleteTask.java
+++ b/caches/tck/src/main/java/org/commonjava/maven/galley/cache/iotasks/DeleteTask.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.galley.cache.iotasks;
+
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+
+public final class DeleteTask
+        extends CacheProviderWorkingTask
+        implements Callable<Boolean>
+{
+    private Boolean callResult;
+
+    public DeleteTask( CacheProvider provider, String content, ConcreteResource resource, CountDownLatch controlLatch )
+    {
+        super( provider, content, resource, controlLatch, -1 );
+    }
+
+    public DeleteTask( CacheProvider provider, String content, ConcreteResource resource, CountDownLatch controlLatch,
+                       long waiting )
+    {
+        super( provider, content, resource, controlLatch, waiting );
+    }
+
+    @Override
+    public void run()
+    {
+        try
+        {
+            if ( waiting > 0 )
+            {
+                Thread.sleep( waiting );
+            }
+            System.out.println( "<<<DeleteTask>>> start to delete resource" );
+            callResult = provider.delete( resource );
+        }
+        catch ( Exception e )
+        {
+            System.out.println( "Delete Task Runtime Exception." );
+            e.printStackTrace();
+        }
+        finally
+        {
+            if(controlLatch!=null)
+            {
+                controlLatch.countDown();
+            }
+        }
+    }
+
+    @Override
+    public Boolean call()
+    {
+        this.run();
+        return callResult;
+    }
+}

--- a/caches/tck/src/main/java/org/commonjava/maven/galley/cache/iotasks/ReadTask.java
+++ b/caches/tck/src/main/java/org/commonjava/maven/galley/cache/iotasks/ReadTask.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.galley.cache.iotasks;
+
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+
+public final class ReadTask
+        extends CacheProviderWorkingTask
+        implements Callable<String>
+{
+    private String readingResult;
+
+    public ReadTask( CacheProvider provider, String content, ConcreteResource resource, CountDownLatch controlLatch )
+    {
+        super( provider, content, resource, controlLatch, -1 );
+    }
+
+    public ReadTask( CacheProvider provider, String content, ConcreteResource resource, CountDownLatch controlLatch,
+                     long waiting )
+    {
+        super( provider, content, resource, controlLatch, waiting );
+    }
+
+    @Override
+    public void run()
+    {
+        try
+        {
+            final String threadName = Thread.currentThread().getName();
+            final InputStream in = provider.openInputStream( resource );
+            if ( in == null )
+            {
+                System.out.println( "Can not read content as the input stream is null." );
+                if ( controlLatch != null )
+                {
+                    controlLatch.countDown();
+                }
+                return;
+            }
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            int read = -1;
+            final byte[] buf = new byte[512];
+            System.out.println(
+                    String.format( "[%s] <<<ReadTask>>> will start to read from the resource with inputStream %s",
+                                   threadName, in.getClass().getName() ) );
+            while ( ( read = in.read( buf ) ) > -1 )
+            {
+                if ( waiting > 0 )
+                {
+                    Thread.sleep( waiting );
+                }
+                baos.write( buf, 0, read );
+            }
+            baos.close();
+            in.close();
+            System.out.println(
+                    String.format( "[%s] <<<ReadTask>>> reading from the resource done with inputStream %s", threadName,
+                                   in.getClass().getName() ) );
+            readingResult = new String( baos.toByteArray(), "UTF-8" );
+            if ( controlLatch != null )
+            {
+                controlLatch.countDown();
+            }
+        }
+        catch ( Exception e )
+        {
+            System.out.println( "Read Task Runtime Exception." );
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public String call()
+    {
+        this.run();
+        return readingResult;
+    }
+}

--- a/caches/tck/src/main/java/org/commonjava/maven/galley/cache/iotasks/WriteTask.java
+++ b/caches/tck/src/main/java/org/commonjava/maven/galley/cache/iotasks/WriteTask.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.galley.cache.iotasks;
+
+import java.io.ByteArrayInputStream;
+import java.io.OutputStream;
+import java.util.concurrent.CountDownLatch;
+
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
+
+public final class WriteTask
+        extends CacheProviderWorkingTask
+{
+    public WriteTask( CacheProvider provider, String content, ConcreteResource resource, CountDownLatch controlLatch,
+                      long waiting )
+    {
+        super( provider, content, resource, controlLatch, waiting );
+    }
+
+    public WriteTask( CacheProvider provider, String content, ConcreteResource resource, CountDownLatch controlLatch )
+    {
+        super( provider, content, resource, controlLatch, -1 );
+    }
+
+    @Override
+    public void run()
+    {
+        try
+        {
+            final String threadName = Thread.currentThread().getName();
+            final OutputStream out = provider.openOutputStream( resource );
+            final ByteArrayInputStream bais = new ByteArrayInputStream( content.getBytes() );
+            int read = -1;
+            final byte[] buf = new byte[512];
+            System.out.println(
+                    String.format( "[%s] <<<WriteTask>>> start to write to the resource with outputStream %s",
+                                   threadName, out.getClass().getName() ) );
+            while ( ( read = bais.read( buf ) ) > -1 )
+            {
+                if ( waiting > 0 )
+                {
+                    Thread.sleep( waiting );
+                }
+                out.write( buf, 0, read );
+            }
+            out.close();
+            System.out.println(
+                    String.format( "[%s] <<<WriteTask>>> writing to the resource done with outputStream %s", threadName,
+                                   out.getClass().getName() ) );
+            if ( controlLatch != null )
+            {
+                controlLatch.countDown();
+            }
+        }
+        catch ( Exception e )
+        {
+            System.out.println( "Write Task Runtime Exception." );
+            e.printStackTrace();
+        }
+    }
+}

--- a/caches/tck/src/main/java/org/commonjava/maven/galley/cache/testutil/TestIOUtils.java
+++ b/caches/tck/src/main/java/org/commonjava/maven/galley/cache/testutil/TestIOUtils.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.galley.cache.testutil;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CountDownLatch;
+
+public final class TestIOUtils
+{
+    public static String readFromStream( InputStream in )
+            throws IOException
+    {
+        if ( in == null )
+        {
+            System.out.println( "Can not read content as the input stream is null." );
+            return null;
+        }
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        int read;
+        final byte[] buf = new byte[512];
+        while ( ( read = in.read( buf ) ) > -1 )
+        {
+            baos.write( buf, 0, read );
+        }
+
+        String readingResult = new String( baos.toByteArray(), "UTF-8" );
+        baos.close();
+        in.close();
+
+        return readingResult;
+    }
+
+    public static void latchWait( CountDownLatch latch )
+    {
+        try
+        {
+            latch.await();
+        }
+        catch ( InterruptedException e )
+        {
+            System.out.println( "Threads await Exception." );
+        }
+    }
+
+}


### PR DESCRIPTION
I've added some tests both for FLCProvider and PartyLineCachProvider, to test big file io performance for both provider, but seems it is not good enough, even some suspicious dead lock there. I just ignored that 2 tests, and try to find what's wrong there.