### PR TITLE
Wrapping ISPN lock in active ISPN transaction

### DIFF
--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/SimpleCacheInstance.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/SimpleCacheInstance.java
@@ -290,8 +290,8 @@ public class SimpleCacheInstance<K,V>
                      }
                      catch ( RuntimeException e )
                      {
-			 Logger logger = LoggerFactory.getLogger( SimpleCacheInstance.this.getClass() );
-			 logger.error( String.format( "Failed to unlock key %s: %s", key, e.getMessage() ), e );
+                         Logger logger = LoggerFactory.getLogger( SimpleCacheInstance.this.getClass() );
+                         logger.error( String.format( "Failed to unlock key %s: %s", key, e.getMessage() ), e );
                          return false;
                      }
                  } );


### PR DESCRIPTION
   Some lock sequences are not correct, which is not wrapped in an
active ISPN transaction. This caused the dead lock in ISPN lock. So add
some logic to make these lock/unlock operations in active transaction.