### PR TITLE
tone down logging and clear NFC when a file is stored

### DIFF
--- a/core/src/main/java/org/commonjava/maven/galley/internal/TransferManagerImpl.java
+++ b/core/src/main/java/org/commonjava/maven/galley/internal/TransferManagerImpl.java
@@ -633,6 +633,8 @@ public class TransferManagerImpl
         {
             out = target.openOutputStream( TransferOperation.UPLOAD, true, eventMetadata );
             copy( stream, out );
+
+            nfc.clearMissing( resource );
         }
         catch ( final IOException e )
         {

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingInputStream.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingInputStream.java
@@ -110,22 +110,22 @@ public final class ChecksummingInputStream
     public int read()
             throws IOException
     {
-        logger.trace( "READ: {}", transfer );
+//        logger.trace( "READ: {}", transfer );
         int data = super.read();
         logger.trace( "{} input", data );
         if ( data > -1 )
         {
             size++;
-            logger.trace( "Updating with: {} (raw: {})", ( (byte) data & 0xff ), data );
+//            logger.trace( "Updating with: {} (raw: {})", ( (byte) data & 0xff ), data );
             for ( final AbstractChecksumGenerator checksum : checksums )
             {
                 checksum.update( (byte) data );
             }
         }
-        else
-        {
-            logger.trace( "READ: <EOF>" );
-        }
+//        else
+//        {
+//            logger.trace( "READ: <EOF>" );
+//        }
 
         return data;
     }
@@ -155,7 +155,7 @@ public final class ChecksummingInputStream
         }
 
         size += read;
-        logger.trace( "Updating with [buffer of size: {}]", read );
+//        logger.trace( "Updating with [buffer of size: {}]", read );
         for ( final AbstractChecksumGenerator checksum : checksums )
         {
             for ( int i = off; i < off + read; i++ )

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStream.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStream.java
@@ -101,13 +101,13 @@ public final class ChecksummingOutputStream
     public void write( final int data )
         throws IOException
     {
-        logger.trace( "WRITE: {}", transfer );
+//        logger.trace( "WRITE: {}", transfer );
         super.write( data );
 
         size++;
         byte b = (byte) ( data & 0xff );
 
-        logger.trace( "Updating with: {} (raw: {})", b, data );
+//        logger.trace( "Updating with: {} (raw: {})", b, data );
 
         for ( final AbstractChecksumGenerator checksum : checksums )
         {


### PR DESCRIPTION
Logging in Checksumming*Stream was so verbose it could change timing on stream ops and change race condition expression, so I disabled the TRACE in read() and write() operations.

Also, clear NFC when a file is stored.