### PR TITLE
TransferDecorator implementations not using package-type variants of SpecialPathManager methods

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/model/FilePatternMatcher.java
+++ b/api/src/main/java/org/commonjava/maven/galley/model/FilePatternMatcher.java
@@ -59,4 +59,10 @@ public class FilePatternMatcher
     {
         return pattern.hashCode();
     }
+
+    @Override
+    public String toString()
+    {
+        return "FilePatternMatcher{" + pattern + '}';
+    }
 }

--- a/api/src/main/java/org/commonjava/maven/galley/model/PathPatternMatcher.java
+++ b/api/src/main/java/org/commonjava/maven/galley/model/PathPatternMatcher.java
@@ -57,4 +57,10 @@ public class PathPatternMatcher
     {
         return pattern.hashCode();
     }
+
+    @Override
+    public String toString()
+    {
+        return "PathPatternMatcher{" + pattern + '}';
+    }
 }

--- a/core/src/main/java/org/commonjava/maven/galley/io/ChecksummingTransferDecorator.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/ChecksummingTransferDecorator.java
@@ -139,7 +139,7 @@ public final class ChecksummingTransferDecorator
         Object forceObj = eventMetadata.get( FORCE_CHECKSUM );
         boolean force = Boolean.TRUE.equals( forceObj ) || Boolean.parseBoolean( String.valueOf( forceObj ) );
 
-        SpecialPathInfo specialPathInfo = specialPathManager.getSpecialPathInfo( transfer );
+        SpecialPathInfo specialPathInfo = specialPathManager.getSpecialPathInfo( transfer, eventMetadata.getPackageType() );
 
         logger.trace( "SpecialPathInfo for: {} is: {} (decoratable? {})", transfer, specialPathInfo,
                       ( specialPathInfo == null || specialPathInfo.isDecoratable() ) );
@@ -181,7 +181,7 @@ public final class ChecksummingTransferDecorator
         Object forceObj = eventMetadata.get( FORCE_CHECKSUM );
         boolean force = Boolean.TRUE.equals( forceObj ) || Boolean.parseBoolean( String.valueOf( forceObj ) );
 
-        SpecialPathInfo specialPathInfo = specialPathManager.getSpecialPathInfo( transfer );
+        SpecialPathInfo specialPathInfo = specialPathManager.getSpecialPathInfo( transfer, eventMetadata.getPackageType() );
 
         logger.trace( "SpecialPathInfo for: {} is: {} (decoratable? {})", transfer, specialPathInfo,
                       ( specialPathInfo == null || specialPathInfo.isDecoratable() ) );
@@ -222,7 +222,7 @@ public final class ChecksummingTransferDecorator
             return;
         }
 
-        SpecialPathInfo specialPathInfo = specialPathManager.getSpecialPathInfo( transfer );
+        SpecialPathInfo specialPathInfo = specialPathManager.getSpecialPathInfo( transfer, eventMetadata.getPackageType() );
         if ( specialPathInfo == null || specialPathInfo.isDeletable() )
         {
             for ( final AbstractChecksumGeneratorFactory<?> factory : checksumFactories )

--- a/core/src/main/java/org/commonjava/maven/galley/io/SpecialPathManagerImpl.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/SpecialPathManagerImpl.java
@@ -18,6 +18,7 @@ package org.commonjava.maven.galley.io;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.model.SpecialPathInfo;
+import org.commonjava.maven.galley.model.SpecialPathMatcher;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.slf4j.Logger;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.apache.commons.lang.StringUtils.join;
 import static org.commonjava.maven.galley.io.SpecialPathConstants.MVN_SP_PATH_SET;
 import static org.commonjava.maven.galley.io.SpecialPathConstants.NPM_SP_PATH_SET;
 import static org.commonjava.maven.galley.io.SpecialPathConstants.PKG_TYPE_MAVEN;
@@ -98,6 +100,18 @@ public class SpecialPathManagerImpl
         }
 
         pkgtypes.put( pathSet.getPackageType(), pathSet );
+
+        if ( logger.isTraceEnabled() )
+        {
+            final List<SpecialPathMatcher> pathMatchers = new ArrayList<>();
+            for ( SpecialPathInfo info : pathSet.getSpecialPathInfos() )
+            {
+                pathMatchers.add( info.getMatcher() );
+            }
+
+            logger.trace( "Enabling special paths for package: '{}'\n  - {}\n\nCalled from: {}", pathSet.getPackageType(),
+                          join( pathMatchers, "\n  - " ), Thread.currentThread().getStackTrace()[1] );
+        }
     }
 
     @Override


### PR DESCRIPTION
I noticed that TransferDecorators are using the old SpecialPathManager methods that
default to using the 'maven' package type. This is not always appropriate.

I've corrected this by using EventMetadata.getPackageType() in these decorators.