### PR TITLE
Update to Maven 3.5.0 for plugin defaults

### DIFF
--- a/cdi-embedder/src/main/java/org/commonjava/maven/galley/embed/EmbeddableCDIProducer.java
+++ b/cdi-embedder/src/main/java/org/commonjava/maven/galley/embed/EmbeddableCDIProducer.java
@@ -24,6 +24,7 @@ import org.commonjava.maven.galley.io.HashedLocationPathGenerator;
 import org.commonjava.maven.galley.io.NoOpTransferDecorator;
 import org.commonjava.maven.galley.maven.ArtifactManager;
 import org.commonjava.maven.galley.maven.internal.defaults.StandardMaven304PluginDefaults;
+import org.commonjava.maven.galley.maven.internal.defaults.StandardMaven350PluginDefaults;
 import org.commonjava.maven.galley.maven.internal.defaults.StandardMavenPluginImplications;
 import org.commonjava.maven.galley.maven.parse.XMLInfrastructure;
 import org.commonjava.maven.galley.maven.spi.defaults.MavenPluginDefaults;
@@ -100,7 +101,7 @@ public class EmbeddableCDIProducer
         objectMapper = new ObjectMapper();
         objectMapper.registerModules( new ProjectVersionRefSerializerModule() );
 
-        pluginDefaults = new StandardMaven304PluginDefaults();
+        pluginDefaults = new StandardMaven350PluginDefaults();
         pluginImplications = new StandardMavenPluginImplications( xml );
     }
 

--- a/maven/src/main/java/org/commonjava/maven/galley/maven/GalleyMavenBuilder.java
+++ b/maven/src/main/java/org/commonjava/maven/galley/maven/GalleyMavenBuilder.java
@@ -21,7 +21,6 @@ import org.commonjava.maven.galley.TransferManager;
 import org.commonjava.maven.galley.cache.CacheProviderFactory;
 import org.commonjava.maven.galley.maven.internal.ArtifactManagerImpl;
 import org.commonjava.maven.galley.maven.internal.ArtifactMetadataManagerImpl;
-import org.commonjava.maven.galley.maven.internal.defaults.StandardMaven304PluginDefaults;
 import org.commonjava.maven.galley.maven.internal.defaults.StandardMaven350PluginDefaults;
 import org.commonjava.maven.galley.maven.internal.defaults.StandardMavenPluginImplications;
 import org.commonjava.maven.galley.maven.internal.type.StandardTypeMapper;
@@ -198,12 +197,6 @@ public class GalleyMavenBuilder
     public MavenPluginDefaults getPluginDefaults()
     {
         return pluginDefaults;
-    }
-
-    public GalleyMavenBuilder withPluginDefaults( final StandardMaven350PluginDefaults pluginDefaults )
-    {
-        this.pluginDefaults = pluginDefaults;
-        return this;
     }
 
     public XPathManager getXPathManager()

--- a/maven/src/main/java/org/commonjava/maven/galley/maven/GalleyMavenBuilder.java
+++ b/maven/src/main/java/org/commonjava/maven/galley/maven/GalleyMavenBuilder.java
@@ -22,6 +22,7 @@ import org.commonjava.maven.galley.cache.CacheProviderFactory;
 import org.commonjava.maven.galley.maven.internal.ArtifactManagerImpl;
 import org.commonjava.maven.galley.maven.internal.ArtifactMetadataManagerImpl;
 import org.commonjava.maven.galley.maven.internal.defaults.StandardMaven304PluginDefaults;
+import org.commonjava.maven.galley.maven.internal.defaults.StandardMaven350PluginDefaults;
 import org.commonjava.maven.galley.maven.internal.defaults.StandardMavenPluginImplications;
 import org.commonjava.maven.galley.maven.internal.type.StandardTypeMapper;
 import org.commonjava.maven.galley.maven.internal.version.VersionResolverImpl;
@@ -136,7 +137,7 @@ public class GalleyMavenBuilder
 
         if ( pluginDefaults == null )
         {
-            pluginDefaults = new StandardMaven304PluginDefaults();
+            pluginDefaults = new StandardMaven350PluginDefaults();
         }
 
         if ( pluginImplications == null )
@@ -199,7 +200,7 @@ public class GalleyMavenBuilder
         return pluginDefaults;
     }
 
-    public GalleyMavenBuilder withPluginDefaults( final StandardMaven304PluginDefaults pluginDefaults )
+    public GalleyMavenBuilder withPluginDefaults( final StandardMaven350PluginDefaults pluginDefaults )
     {
         this.pluginDefaults = pluginDefaults;
         return this;

--- a/maven/src/main/java/org/commonjava/maven/galley/maven/internal/defaults/StandardMaven350PluginDefaults.java
+++ b/maven/src/main/java/org/commonjava/maven/galley/maven/internal/defaults/StandardMaven350PluginDefaults.java
@@ -15,45 +15,44 @@
  */
 package org.commonjava.maven.galley.maven.internal.defaults;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.enterprise.inject.Alternative;
-import javax.inject.Named;
-
 import org.commonjava.maven.atlas.ident.ref.ProjectRef;
 import org.commonjava.maven.atlas.ident.ref.SimpleProjectRef;
 import org.commonjava.maven.galley.maven.spi.defaults.MavenPluginDefaults;
 
+import javax.enterprise.inject.Alternative;
+import javax.inject.Named;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 @Named
 @Alternative
-public class StandardMaven304PluginDefaults
+public class StandardMaven350PluginDefaults
     implements MavenPluginDefaults
 {
+
     private static final String DGID = "org.apache.maven.plugins";
 
     private static final Map<ProjectRef, String> DEFAULT_VERSIONS = Collections.unmodifiableMap( new HashMap<ProjectRef, String>()
     {
-
         {
-            put( new SimpleProjectRef( DGID, "maven-resources-plugin" ), "2.5" );
-            put( new SimpleProjectRef( DGID, "maven-compiler-plugin" ), "2.3.2" );
-            put( new SimpleProjectRef( DGID, "maven-surefire-plugin" ), "2.10" );
-            put( new SimpleProjectRef( DGID, "maven-jar-plugin" ), "2.3.2" );
-            put( new SimpleProjectRef( DGID, "maven-install-plugin" ), "2.3.1" );
+            put( new SimpleProjectRef( DGID, "maven-resources-plugin" ), "2.6" );
+            put( new SimpleProjectRef( DGID, "maven-compiler-plugin" ), "3.1" );
+            put( new SimpleProjectRef( DGID, "maven-surefire-plugin" ), "2.12.4" );
+            put( new SimpleProjectRef( DGID, "maven-jar-plugin" ), "2.4" );
+            put( new SimpleProjectRef( DGID, "maven-install-plugin" ), "2.4" );
             put( new SimpleProjectRef( DGID, "maven-deploy-plugin" ), "2.7" );
-            put( new SimpleProjectRef( DGID, "maven-clean-plugin" ), "2.4.1" );
-            put( new SimpleProjectRef( DGID, "maven-site-plugin" ), "3.0" );
+            put( new SimpleProjectRef( DGID, "maven-clean-plugin" ), "2.5" );
+            put( new SimpleProjectRef( DGID, "maven-site-plugin" ), "3.3" );
             put( new SimpleProjectRef( DGID, "maven-ejb-plugin" ), "2.3" );
-            put( new SimpleProjectRef( DGID, "maven-plugin-plugin" ), "2.9" );
-            put( new SimpleProjectRef( DGID, "maven-war-plugin" ), "2.1.1" );
-            put( new SimpleProjectRef( DGID, "maven-ear-plugin" ), "2.5" );
+            put( new SimpleProjectRef( DGID, "maven-plugin-plugin" ), "3.2" );
+            put( new SimpleProjectRef( DGID, "maven-war-plugin" ), "2.2" );
+            put( new SimpleProjectRef( DGID, "maven-ear-plugin" ), "2.8" );
             put( new SimpleProjectRef( DGID, "maven-rar-plugin" ), "2.2" );
-            put( new SimpleProjectRef( DGID, "maven-antrun-plugin" ), "1.3" );
+            put( new SimpleProjectRef( DGID, "maven-antrun-plugin" ), "1.7" );
             put( new SimpleProjectRef( DGID, "maven-assembly-plugin" ), "2.2-beta-5" );
-            put( new SimpleProjectRef( DGID, "maven-dependency-plugin" ), "2.1" );
-            put( new SimpleProjectRef( DGID, "maven-release-plugin" ), "2.0" );
+            put( new SimpleProjectRef( DGID, "maven-dependency-plugin" ), "2.8" );
+            put( new SimpleProjectRef( DGID, "maven-release-plugin" ), "2.3.2" );
         }
 
         private static final long serialVersionUID = 1L;

--- a/maven/src/test/java/org/commonjava/maven/galley/maven/model/view/AbstractMavenViewTest.java
+++ b/maven/src/test/java/org/commonjava/maven/galley/maven/model/view/AbstractMavenViewTest.java
@@ -34,6 +34,7 @@ import org.commonjava.maven.atlas.ident.ref.ProjectRef;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.commonjava.maven.atlas.ident.ref.SimpleProjectRef;
 import org.commonjava.maven.galley.maven.internal.defaults.StandardMaven304PluginDefaults;
+import org.commonjava.maven.galley.maven.internal.defaults.StandardMaven350PluginDefaults;
 import org.commonjava.maven.galley.maven.internal.defaults.StandardMavenPluginImplications;
 import org.commonjava.maven.galley.maven.parse.XMLInfrastructure;
 import org.commonjava.maven.galley.model.SimpleLocation;
@@ -150,7 +151,7 @@ public abstract class AbstractMavenViewTest
             stack.add( dr );
         }
 
-        return new MavenPomView( pvr, stack, xpath, new StandardMaven304PluginDefaults(),
+        return new MavenPomView( pvr, stack, xpath, new StandardMaven350PluginDefaults(),
                                  new StandardMavenPluginImplications( xml ), xml, activeProfileIds );
     }
 

--- a/maven/src/test/java/org/commonjava/maven/galley/maven/testutil/TestFixture.java
+++ b/maven/src/test/java/org/commonjava/maven/galley/maven/testutil/TestFixture.java
@@ -21,6 +21,7 @@ import org.commonjava.maven.galley.maven.ArtifactMetadataManager;
 import org.commonjava.maven.galley.maven.internal.ArtifactManagerImpl;
 import org.commonjava.maven.galley.maven.internal.ArtifactMetadataManagerImpl;
 import org.commonjava.maven.galley.maven.internal.defaults.StandardMaven304PluginDefaults;
+import org.commonjava.maven.galley.maven.internal.defaults.StandardMaven350PluginDefaults;
 import org.commonjava.maven.galley.maven.internal.defaults.StandardMavenPluginImplications;
 import org.commonjava.maven.galley.maven.internal.type.StandardTypeMapper;
 import org.commonjava.maven.galley.maven.internal.version.VersionResolverImpl;
@@ -128,7 +129,7 @@ public class TestFixture
 
         if ( pluginDefaults == null )
         {
-            pluginDefaults = new StandardMaven304PluginDefaults();
+            pluginDefaults = new StandardMaven350PluginDefaults();
         }
 
         if ( pluginImplications == null )

--- a/testing/maven/src/main/java/org/commonjava/maven/galley/testing/maven/GalleyMavenFixture.java
+++ b/testing/maven/src/main/java/org/commonjava/maven/galley/testing/maven/GalleyMavenFixture.java
@@ -15,11 +15,6 @@
  */
 package org.commonjava.maven.galley.testing.maven;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-
 import org.commonjava.maven.galley.GalleyInitException;
 import org.commonjava.maven.galley.TransferManager;
 import org.commonjava.maven.galley.cache.CacheProviderFactory;
@@ -29,8 +24,6 @@ import org.commonjava.maven.galley.maven.ArtifactManager;
 import org.commonjava.maven.galley.maven.ArtifactMetadataManager;
 import org.commonjava.maven.galley.maven.GalleyMaven;
 import org.commonjava.maven.galley.maven.GalleyMavenBuilder;
-import org.commonjava.maven.galley.maven.internal.defaults.StandardMaven304PluginDefaults;
-import org.commonjava.maven.galley.maven.internal.defaults.StandardMaven350PluginDefaults;
 import org.commonjava.maven.galley.maven.internal.type.StandardTypeMapper;
 import org.commonjava.maven.galley.maven.internal.version.VersionResolverImpl;
 import org.commonjava.maven.galley.maven.model.view.XPathManager;
@@ -54,6 +47,11 @@ import org.commonjava.maven.galley.testing.core.cache.TestCacheProvider;
 import org.commonjava.maven.galley.testing.core.transport.TestTransport;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 public class GalleyMavenFixture
     extends ExternalResource
@@ -590,13 +588,6 @@ public class GalleyMavenFixture
     {
         checkInitialized();
         mavenBuilder.withPomReader( pomReader );
-        return this;
-    }
-
-    public GalleyMavenFixture withPluginDefaults( final StandardMaven350PluginDefaults pluginDefaults )
-    {
-        checkInitialized();
-        mavenBuilder.withPluginDefaults( pluginDefaults );
         return this;
     }
 

--- a/testing/maven/src/main/java/org/commonjava/maven/galley/testing/maven/GalleyMavenFixture.java
+++ b/testing/maven/src/main/java/org/commonjava/maven/galley/testing/maven/GalleyMavenFixture.java
@@ -30,6 +30,7 @@ import org.commonjava.maven.galley.maven.ArtifactMetadataManager;
 import org.commonjava.maven.galley.maven.GalleyMaven;
 import org.commonjava.maven.galley.maven.GalleyMavenBuilder;
 import org.commonjava.maven.galley.maven.internal.defaults.StandardMaven304PluginDefaults;
+import org.commonjava.maven.galley.maven.internal.defaults.StandardMaven350PluginDefaults;
 import org.commonjava.maven.galley.maven.internal.type.StandardTypeMapper;
 import org.commonjava.maven.galley.maven.internal.version.VersionResolverImpl;
 import org.commonjava.maven.galley.maven.model.view.XPathManager;
@@ -592,7 +593,7 @@ public class GalleyMavenFixture
         return this;
     }
 
-    public GalleyMavenFixture withPluginDefaults( final StandardMaven304PluginDefaults pluginDefaults )
+    public GalleyMavenFixture withPluginDefaults( final StandardMaven350PluginDefaults pluginDefaults )
     {
         checkInitialized();
         mavenBuilder.withPluginDefaults( pluginDefaults );


### PR DESCRIPTION
@jdcasey Utilised https://github.com/apache/maven/blob/maven-3.5.0/maven-core/src/main/resources/META-INF/plexus/default-bindings.xml and https://github.com/apache/maven/blob/master/maven-core/src/main/resources/META-INF/plexus/default-bindings.xml to locate default versions. 