### PR TITLE
Add local file cache for expiration deletion in FLCP

### DIFF
--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderFactory.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderFactory.java
@@ -18,6 +18,7 @@ package org.commonjava.maven.galley.cache.infinispan;
 import org.commonjava.maven.galley.GalleyInitException;
 import org.commonjava.maven.galley.cache.CacheProviderFactory;
 import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProvider;
+import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.maven.galley.spi.event.FileEventManager;
 import org.commonjava.maven.galley.spi.io.PathGenerator;
@@ -42,12 +43,17 @@ public class FastLocalCacheProviderFactory
 
     private transient FastLocalCacheProvider provider;
 
-    public FastLocalCacheProviderFactory( File cacheDir, File nfsDir, CacheInstance<String, String> nfsUsageCache, ExecutorService executor )
+    private final CacheInstance<String, ConcreteResource> localFilePathCache;
+
+    public FastLocalCacheProviderFactory( File cacheDir, File nfsDir, CacheInstance<String, String> nfsUsageCache,
+                                          CacheInstance<String, ConcreteResource> localFilePathCache,
+                                          ExecutorService executor )
     {
         this.cacheDir = cacheDir;
         this.nfsDir = nfsDir;
         this.nfsUsageCache = nfsUsageCache;
         this.executor = executor;
+        this.localFilePathCache = localFilePathCache;
     }
 
     @Override
@@ -62,7 +68,7 @@ public class FastLocalCacheProviderFactory
 
             provider =
                     new FastLocalCacheProvider( pl, nfsUsageCache, pathGenerator, fileEventManager, transferDecorator,
-                                                executor, nfsDir.getPath() );
+                                                executor, nfsDir.getPath(), localFilePathCache );
         }
 
         return provider;

--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderFactory.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderFactory.java
@@ -56,6 +56,19 @@ public class FastLocalCacheProviderFactory
         this.localFilePathCache = localFilePathCache;
     }
 
+    public FastLocalCacheProviderFactory( File cacheDir, File nfsDir, CacheInstance<String, String> nfsUsageCache,
+                                          ExecutorService executor )
+    {
+        this.cacheDir = cacheDir;
+        this.nfsDir = nfsDir;
+        this.nfsUsageCache = nfsUsageCache;
+        this.executor = executor;
+        this.localFilePathCache = new SimpleCacheInstance<>( NFSOwnerCacheProducer.DEFAULT_LOCAL_CACHE_FILE_NAME,
+                                                             new NFSOwnerCacheProducer().getCacheMgr()
+                                                                                        .getCache(
+                                                                                                NFSOwnerCacheProducer.DEFAULT_LOCAL_CACHE_FILE_NAME ) );
+    }
+
     @Override
     public synchronized CacheProvider create( PathGenerator pathGenerator, TransferDecorator transferDecorator,
                                  FileEventManager fileEventManager )

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/AbstractFastLocalCacheBMUnitTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/AbstractFastLocalCacheBMUnitTest.java
@@ -67,6 +67,8 @@ public abstract class AbstractFastLocalCacheBMUnitTest
 
     protected Cache<String, String> cache = CACHE_MANAGER.getCache( NFSOwnerCacheProducer.CACHE_NAME );
 
+    protected Cache<String, ConcreteResource> localFileCache = CACHE_MANAGER.getCache( "localFileCache" );
+
     protected String result;
 
     @BeforeClass
@@ -83,7 +85,8 @@ public abstract class AbstractFastLocalCacheBMUnitTest
         provider =
                 new FastLocalCacheProvider( new PartyLineCacheProvider( temp.newFolder(), pathgen, events, decorator ),
                                             new SimpleCacheInstance<>( name.getMethodName(), cache ), pathgen, events,
-                                            decorator, executor, nfsBasePath );
+                                            decorator, executor, nfsBasePath,
+                                            new SimpleCacheInstance<>( "localFileCache", localFileCache ) );
     }
 
     @After
@@ -238,7 +241,7 @@ public abstract class AbstractFastLocalCacheBMUnitTest
             {
                 InputStream in = provider.openInputStream( new ConcreteResource( loc, fname ) );
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                int read = -1;
+                int read;
                 byte[] buf = new byte[512];
                 while ( ( read = in.read( buf ) ) > -1 )
                 {
@@ -287,7 +290,7 @@ public abstract class AbstractFastLocalCacheBMUnitTest
 
                 InputStream in = provider.openInputStream( new ConcreteResource( loc2, fname ) );
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                int read = -1;
+                int read;
                 byte[] buf = new byte[512];
                 while ( ( read = in.read( buf ) ) > -1 )
                 {

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/AbstractFastLocalCacheBMUnitTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/AbstractFastLocalCacheBMUnitTest.java
@@ -67,7 +67,7 @@ public abstract class AbstractFastLocalCacheBMUnitTest
 
     protected Cache<String, String> cache = CACHE_MANAGER.getCache( NFSOwnerCacheProducer.CACHE_NAME );
 
-    protected Cache<String, ConcreteResource> localFileCache = CACHE_MANAGER.getCache( "localFileCache" );
+    protected Cache<String, ConcreteResource> localFileCache = CACHE_MANAGER.getCache( "simpleLocalFileCacheTest" );
 
     protected String result;
 

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderBaseTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderBaseTest.java
@@ -73,19 +73,7 @@ public class FastLocalCacheProviderBaseTest
 
         CACHE_MANAGER = new NFSOwnerCacheProducer().getCacheMgr();
         nfsOwnerCache = CACHE_MANAGER.getCache( NFSOwnerCacheProducer.CACHE_NAME );
-
-        Configuration config = new ConfigurationBuilder().eviction()
-                                                         .strategy( EvictionStrategy.LRU )
-                                                         .size( 1000 )
-                                                         .type( EvictionType.COUNT )
-                                                         .expiration()
-                                                         .lifespan( 1000L )
-                                                         .wakeUpInterval( 100L )
-                                                         .maxIdle( 1000L )
-                                                         .build();
-        final String LOCAL_FILE_CACHE_NAME = "localFileCache";
-        CACHE_MANAGER.defineConfiguration( LOCAL_FILE_CACHE_NAME, config );
-        localFileCache = CACHE_MANAGER.getCache( LOCAL_FILE_CACHE_NAME );
+        localFileCache = CACHE_MANAGER.getCache( NFSOwnerCacheProducer.LOCAL_CACHE_FILE_NAME_FOR_TEST );
     }
 
 

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderConcurrentIOTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderConcurrentIOTest.java
@@ -88,7 +88,7 @@ public class FastLocalCacheProviderConcurrentIOTest
 
     private final Cache<String, String> cache = CACHE_MANAGER.getCache( NFSOwnerCacheProducer.CACHE_NAME );
 
-    private final Cache<String, ConcreteResource> localFileCache = CACHE_MANAGER.getCache( "localFileCache" );
+    private final Cache<String, ConcreteResource> localFileCache = CACHE_MANAGER.getCache( "simpleLocalFileCacheTest" );
 
     private PartyLineCacheProvider plProvider;
 

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderConcurrentIOTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderConcurrentIOTest.java
@@ -36,7 +36,6 @@ import org.jboss.byteman.contrib.bmunit.BMScript;
 import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -89,6 +88,8 @@ public class FastLocalCacheProviderConcurrentIOTest
 
     private final Cache<String, String> cache = CACHE_MANAGER.getCache( NFSOwnerCacheProducer.CACHE_NAME );
 
+    private final Cache<String, ConcreteResource> localFileCache = CACHE_MANAGER.getCache( "localFileCache" );
+
     private PartyLineCacheProvider plProvider;
 
     private final ExecutorService executor = Executors.newFixedThreadPool( 4 );
@@ -111,7 +112,7 @@ public class FastLocalCacheProviderConcurrentIOTest
         plProvider = new PartyLineCacheProvider( temp.newFolder(), pathgen, events, decorator );
 
         provider = new FastLocalCacheProvider( plProvider, new SimpleCacheInstance<>( "test", cache ), pathgen, events,
-                                               decorator, executor, nfsBasePath );
+                                               decorator, executor, nfsBasePath, new SimpleCacheInstance<>( "localFileCache", localFileCache ));
 
         latch = new CountDownLatch( 2 );
     }

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/routes/RoutingCacheProviderWrapperTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/routes/RoutingCacheProviderWrapperTest.java
@@ -86,9 +86,14 @@ public class RoutingCacheProviderWrapperTest
 
         final File cacheDir = temp.newFolder();
         partylineFac = new PartyLineCacheProviderFactory( cacheDir );
+        DefaultCacheManager cacheManager = new DefaultCacheManager();
         SimpleCacheInstance<String, String> cacheInstance =
-                new SimpleCacheInstance<>( "test", new DefaultCacheManager().getCache() );
+                new SimpleCacheInstance<>( "test", cacheManager.getCache( "simpleNfsCache" ) );
+        SimpleCacheInstance<String, ConcreteResource> testLocalFileCacheInstance =
+                new SimpleCacheInstance<>( "testLocalFileCache",
+                                           cacheManager.getCache( "simpleLocalFileCache" ) );
         fastLocalFac = new FastLocalCacheProviderFactory( cacheDir, temp.newFolder(), cacheInstance,
+                                                          testLocalFileCacheInstance,
                                                           Executors.newFixedThreadPool( 5 ) );
     }
 


### PR DESCRIPTION
As we will make the local cache of artifacts expiration automatically periodically, here uses a new ISPN cache to record the local file resource, and then trigger the deletion by ISPN cache expiration mechanism.