### PR TITLE
It appears that FLCP is getting stuck while retrieving/init'ing Transfer instances

### DIFF
--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProvider.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProvider.java
@@ -915,14 +915,20 @@ public class FastLocalCacheProvider
     }
 
     @Override
-    public Transfer getTransfer( ConcreteResource resource )
+    public synchronized Transfer getTransfer( final ConcreteResource resource )
     {
-        return transferCache.computeIfAbsent( resource,
-                                              r -> new Transfer( r, this, fileEventManager, transferDecorator ) );
+        Transfer t = transferCache.get( resource );
+        if ( t == null )
+        {
+            t = new Transfer( resource, this, fileEventManager, transferDecorator );
+            transferCache.put( new ConcreteResource( resource.getLocation(), resource.getPath() ), t );
+        }
+
+        return t;
     }
 
     @Override
-    public void clearTransferCache()
+    public synchronized void clearTransferCache()
     {
         transferCache.clear();
     }


### PR DESCRIPTION
The transfers cache in FLCP has been de-syncrhonized in favor of ReentrantLock. The
problem is the map of ReentrantLocks is keyed by Transfer instances, and we don't
have one of those yet. So, we need to put the synchronized keywords back in for
getTransfer(..) and clearTransferCache().