### PR TITLE
Support metric node prefix for clustering env

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/config/TransportMetricConfig.java
+++ b/api/src/main/java/org/commonjava/maven/galley/config/TransportMetricConfig.java
@@ -22,6 +22,12 @@ public interface TransportMetricConfig
     boolean isEnabled();
 
     /**
+     * For clustering. Return node prefix. This will be prepended to metric names.
+     * @return null if not clustered.
+     */
+    String getNodePrefix();
+
+    /**
      * Get metric unique name for the given location.
      * @param location from where to download artifacts,
      *                 e.g., maven:remote:test, maven:remote:koji-com.google.guava-guava-parent-14.0.1

--- a/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
+++ b/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
@@ -71,6 +71,12 @@ public class TestCDIProvider
         }
 
         @Override
+        public String getNodePrefix()
+        {
+            return null;
+        }
+
+        @Override
         public String getMetricUniqueName( Location location )
         {
             return null;

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,11 @@
       </dependency>
 
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.7</version>
+      </dependency>
+      <dependency>
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
         <version>2.6</version>

--- a/transports/httpclient/pom.xml
+++ b/transports/httpclient/pom.xml
@@ -49,6 +49,10 @@
       <artifactId>httpcore</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
@@ -18,6 +18,7 @@ package org.commonjava.maven.galley.transport.htcli.internal;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.ClassUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
@@ -97,15 +98,17 @@ public final class HttpDownload
 
         logger.trace( "Download metric enabled, location: {}", location );
 
+        String cls = ClassUtils.getAbbreviatedName( getClass().getName(), 1 ); // e.g., foo.bar.ClassA -> f.b.ClassA
+
         Timer repoTimer = null;
         String metricName = metricConfig.getMetricUniqueName( location );
         if ( metricName != null )
         {
-            repoTimer = metricRegistry.timer( name( getClass(), "call", metricName ) );
+            repoTimer = metricRegistry.timer( name( metricConfig.getNodePrefix(), cls, "call", metricName ) );
             logger.trace( "Measure repo metric, metricName: {}", metricName );
         }
 
-        final Timer globalTimer = metricRegistry.timer( name( getClass(), "call" ) );
+        final Timer globalTimer = metricRegistry.timer( name( metricConfig.getNodePrefix(), cls, "call" ) );
         final Timer.Context globalTimerContext = globalTimer.time();
         Timer.Context repoTimerContext = null;
         if ( repoTimer != null )

--- a/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownloadTest.java
+++ b/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownloadTest.java
@@ -67,6 +67,12 @@ public class HttpDownloadTest
         }
 
         @Override
+        public String getNodePrefix()
+        {
+            return null;
+        }
+
+        @Override
         public String getMetricUniqueName( Location location )
         {
             if ( location.getName().equals( "test" ) )


### PR DESCRIPTION
Also, use the abbreviated class name for metric name, e.g., foo.bar.ClassA -> f.b.ClassA