### PR TITLE
Change compiling level to java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,9 +380,8 @@
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <!-- override javaVersion above so we can include this in PME, which has to run in JDK 1.6 environments still. -->
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>${javaVersion}</source>
+            <target>${javaVersion}</target>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
   As pme has switched to java 8, we do not need to make galley still
keep java 7 level.