### PR TITLE
Fixing head request existence check error of !allowSnapshot

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/util/TransferUtils.java
+++ b/api/src/main/java/org/commonjava/maven/galley/util/TransferUtils.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.galley.util;
+
+import org.commonjava.maven.atlas.ident.util.SnapshotUtils;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.model.Transfer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TransferUtils
+{
+    private static final Logger logger = LoggerFactory.getLogger( TransferUtils.class );
+
+    /**
+     * Is a transfer should be filtered out based on transfer's metadata of allow snapshots and allow releases?
+     *
+     * @param transfer
+     * @return true - filtered out; false - not filtered
+     */
+    public static boolean filterTransfer( final Transfer transfer )
+    {
+        final Location loc = transfer.getLocation();
+        final boolean allowsSnapshots = loc.allowsSnapshots();
+        final boolean allowsReleases = loc.allowsReleases();
+        if ( !allowsSnapshots || !allowsReleases )
+        {
+            if ( transfer.isFile() )
+            {
+                final String path = transfer.getPath();
+                // pattern for "groupId path/(artifactId)/(version)/(filename)"
+                // where the filename starts with artifactId-version and is followed by - or .
+                //                final Pattern pattern = Pattern.compile( ".*/([^/]+)/([^/]+)/(\\1-\\2[-.][^/]+)$" );
+                // NOS-1434 all files with snapshot version(in snapshot folder) should be ignored if !allowsSnapshots
+                final Pattern pattern = Pattern.compile( ".*/([^/]+)/([^/]+)/(.[^/]+)$" );
+                final Matcher matcher = pattern.matcher( path );
+                if ( matcher.find() )
+                {
+                    String version = matcher.group( 2 );
+
+                    final boolean isSnapshot = SnapshotUtils.isSnapshotVersion( version );
+                    if ( ( isSnapshot && !allowsSnapshots ) || ( !isSnapshot && !allowsReleases ) )
+                    {
+                        logger.debug( "Path {} is filtered out because snapshots/releases disabled" );
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/org/commonjava/maven/galley/internal/xfer/ExistenceHandler.java
+++ b/core/src/main/java/org/commonjava/maven/galley/internal/xfer/ExistenceHandler.java
@@ -27,6 +27,7 @@ import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
 import org.commonjava.maven.galley.spi.transport.ExistenceJob;
 import org.commonjava.maven.galley.spi.transport.Transport;
+import org.commonjava.maven.galley.util.TransferUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +57,12 @@ public class ExistenceHandler
         if ( nfc.isMissing( resource ) )
         {
             logger.debug( "NFC: Already marked as missing: {}", resource );
+            return false;
+        }
+
+        if ( TransferUtils.filterTransfer( transfer ) )
+        {
+            logger.info( "Transfer has been filtered by transfer's metadata settings", resource );
             return false;
         }
 

--- a/transports/httpclient/pom.xml
+++ b/transports/httpclient/pom.xml
@@ -29,6 +29,10 @@
   <name>Galley :: Transports :: HttpClient Transport</name>
   <dependencies>
     <dependency>
+      <groupId>org.commonjava.maven.galley</groupId>
+      <artifactId>galley-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.commonjava.util</groupId>
       <artifactId>jhttpc</artifactId>
     </dependency>

--- a/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/ContentFilteringTransferDecoratorTest.java
+++ b/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/ContentFilteringTransferDecoratorTest.java
@@ -133,31 +133,9 @@ public class ContentFilteringTransferDecoratorTest
             throws Exception
     {
         final String fname = "/commons-codec/commons-codec/11-SNAPSHOT/maven-metadata.xml.md5";
-
         final String content = "kljsjdlfkjsdlkj123j13=20=s0dfjklxjkj";
-        fixture.getServer().expect( "GET", fixture.formatUrl( fname ), 200, content );
-
-        final String baseUri = fixture.getBaseUri();
-        final SimpleHttpLocation location = new SimpleHttpLocation( "test", baseUri, false, true, true, true, null );
-        final Transfer transfer = fixture.getTransfer( new ConcreteResource( location, fname ) );
-        final String url = fixture.formatUrl( fname );
-
-        assertThat( transfer.exists(), equalTo( false ) );
-
-        HttpDownload dl = new HttpDownload( url, location, transfer, new HashMap<Transfer, Long>(), new EventMetadata(),
-                                            fixture.getHttp(), new ObjectMapper(), metricRegistry, metricConfig );
-
-        DownloadJob resultJob = dl.call();
-
-        assertThat( resultJob, notNullValue() );
-
-        Transfer result = resultJob.getTransfer();
-
-        ContentsFilteringTransferDecorator decorator = new ContentsFilteringTransferDecorator();
-        OverriddenBooleanValue value = decorator.decorateExists( result, new EventMetadata() );
-
-        assertThat( value.overrides(), equalTo( true ) );
-        assertThat( value.getResult(), equalTo( false ) );
+        Transfer result = getTestHttpTransfer( fname, content );
+        assertThat( result.exists(), equalTo( false ) );
     }
 
 
@@ -166,31 +144,25 @@ public class ContentFilteringTransferDecoratorTest
             throws Exception
     {
         final String fname = "/commons-codec/commons-codec/11-SNAPSHOT/commons-codec-11-SNAPSHOT.jar";
-
         final String content = "This is a jar";
-        fixture.getServer().expect( "GET", fixture.formatUrl( fname ), 200, content );
+        Transfer result = getTestHttpTransfer( fname, content );
+        assertThat( result.exists(), equalTo( false ) );
+    }
+
+    private Transfer getTestHttpTransfer(final String path, final String content) throws Exception{
+        fixture.getServer().expect( "GET", fixture.formatUrl( path ), 200, content );
 
         final String baseUri = fixture.getBaseUri();
         final SimpleHttpLocation location = new SimpleHttpLocation( "test", baseUri, false, true, true, true, null );
-        final Transfer transfer = fixture.getTransfer( new ConcreteResource( location, fname ) );
-        final String url = fixture.formatUrl( fname );
+        final Transfer transfer = fixture.getTransfer( new ConcreteResource( location, path ) );
+        final String url = fixture.formatUrl( path );
 
         assertThat( transfer.exists(), equalTo( false ) );
 
         HttpDownload dl = new HttpDownload( url, location, transfer, new HashMap<Transfer, Long>(), new EventMetadata(),
                                             fixture.getHttp(), new ObjectMapper(), metricRegistry, metricConfig );
 
-        DownloadJob resultJob = dl.call();
-
-        assertThat( resultJob, notNullValue() );
-
-        Transfer result = resultJob.getTransfer();
-
-        ContentsFilteringTransferDecorator decorator = new ContentsFilteringTransferDecorator();
-        OverriddenBooleanValue value = decorator.decorateExists( result, new EventMetadata() );
-
-        assertThat( value.overrides(), equalTo( true ) );
-        assertThat( value.getResult(), equalTo( false ) );
+        return dl.call().getTransfer();
     }
 
     @Test


### PR DESCRIPTION
Added a TransferUtils.filterTransfer to utilize this filter function, and then used in both ContentsFilterTransferDecorator and ExistenceHandler to make the exists check working properly.