### PR TITLE
Fix transfer filtering of existence

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/util/TransferUtils.java
+++ b/api/src/main/java/org/commonjava/maven/galley/util/TransferUtils.java
@@ -41,7 +41,7 @@ public class TransferUtils
         final boolean allowsReleases = loc.allowsReleases();
         if ( !allowsSnapshots || !allowsReleases )
         {
-            if ( transfer.isFile() )
+            if ( !transfer.isDirectory() )
             {
                 final String path = transfer.getPath();
                 // pattern for "groupId path/(artifactId)/(version)/(filename)"
@@ -57,7 +57,7 @@ public class TransferUtils
                     final boolean isSnapshot = SnapshotUtils.isSnapshotVersion( version );
                     if ( ( isSnapshot && !allowsSnapshots ) || ( !isSnapshot && !allowsReleases ) )
                     {
-                        logger.debug( "Path {} is filtered out because snapshots/releases disabled" );
+                        logger.debug( "Path {} is filtered out because snapshots/releases disabled", path );
                         return true;
                     }
                 }


### PR DESCRIPTION
  For the first time of access of resource, the transfer is null, which
means it's not both file and directory. So the transfer.isFile will not
work. According to this, we should use !transfer.isDirectory to filter
it out