### PR TITLE
Deprecated FastlocalCacheProvider and disabled related unit test

### DIFF
--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProvider.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProvider.java
@@ -75,9 +75,12 @@ import java.util.concurrent.locks.ReentrantLock;
  * provider in CDI environment, please don't forget to set the system property "galley.nfs.basedir" to specify this directory
  * as this provider will use it to get the nfs root directory by default. If you want to set this directory by manually,
  * use the parameterized constructor with the "nfsBaseDir" param.
+ *
+ * @deprecated As we will enable partyline level distributed cache provider in the future, this fast local one will not be used furthermore
  */
 @SuppressWarnings( "unchecked" )
 @Listener
+@Deprecated
 public class FastLocalCacheProvider
         implements CacheProvider, CacheProvider.AdminView
 {

--- a/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderFactory.java
+++ b/caches/infinispan/src/main/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderFactory.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutorService;
 /**
  * Created by jdcasey on 8/30/16.
  */
+@Deprecated
 public class FastLocalCacheProviderFactory
         implements CacheProviderFactory
 {

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/AbstractFastLocalCacheBMUnitTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/AbstractFastLocalCacheBMUnitTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.Executors;
 
 import static org.commonjava.maven.galley.cache.infinispan.CacheTestUtil.getTestEmbeddedCacheManager;
 
+@Deprecated
 public abstract class AbstractFastLocalCacheBMUnitTest
         extends CacheProviderTCK
 {

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderBaseTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderBaseTest.java
@@ -29,6 +29,7 @@ import org.commonjava.maven.galley.spi.io.TransferDecorator;
 import org.infinispan.Cache;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -45,6 +46,7 @@ import static org.commonjava.maven.galley.cache.infinispan.CacheTestUtil.LOCAL_C
 import static org.commonjava.maven.galley.cache.infinispan.CacheTestUtil.getTestEmbeddedCacheManager;
 import static org.junit.Assert.*;
 
+@Ignore
 public class FastLocalCacheProviderBaseTest
 {
     protected static EmbeddedCacheManager CACHE_MANAGER;

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderConcurrentIOTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderConcurrentIOTest.java
@@ -36,6 +36,7 @@ import org.jboss.byteman.contrib.bmunit.BMScript;
 import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -66,6 +67,8 @@ import static org.junit.Assert.fail;
 
 @RunWith( org.jboss.byteman.contrib.bmunit.BMUnitRunner.class )
 @BMUnitConfig( loadDirectory = "target/test-classes/bmunit", debug = true )
+@Deprecated
+@Ignore
 public class FastLocalCacheProviderConcurrentIOTest
 {
     @Rule

--- a/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderIOTest.java
+++ b/caches/infinispan/src/test/java/org/commonjava/maven/galley/cache/infinispan/FastLocalCacheProviderIOTest.java
@@ -21,6 +21,7 @@ import org.commonjava.maven.galley.model.SimpleLocation;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMScript;
 import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,6 +37,8 @@ import static org.junit.Assert.assertThat;
 
 @RunWith( org.jboss.byteman.contrib.bmunit.BMUnitRunner.class )
 @BMUnitConfig( loadDirectory = "target/test-classes/bmunit/common", debug = true )
+@Ignore
+@Deprecated
 public class FastLocalCacheProviderIOTest
         extends AbstractFastLocalCacheBMUnitTest
 {


### PR DESCRIPTION
As we will use partyline level distributed cache provider, I think the
fastlocal one is not needed