### PR TITLE
Fix npm metadata http_meta generation with pathGenerator

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/model/Transfer.java
+++ b/api/src/main/java/org/commonjava/maven/galley/model/Transfer.java
@@ -461,17 +461,13 @@ public class Transfer
             return null;
         }
 
-        final String named = resource.getPath() + extension;
+        final String generatedPath = provider.getGeneratedPath( resource );
+
+        final String named = generatedPath + extension;
 
         final Transfer tx = this;
-        logger.debug( "Creating meta-transfer sibling for: {}", new Object()
-        {
-            @Override
-            public String toString()
-            {
-                return tx + " with name: " + named + " (parent: " + tx.getParent() + ")";
-            }
-        } );
+        logger.debug( "Creating meta-transfer sibling for: {}",
+                      String.format( "%s with name: %s (parent: %s)", tx, named, tx.getParent() ) );
 
         return provider.getTransfer( new ConcreteResource( getLocation(), named ) );
     }

--- a/api/src/main/java/org/commonjava/maven/galley/model/Transfer.java
+++ b/api/src/main/java/org/commonjava/maven/galley/model/Transfer.java
@@ -89,6 +89,11 @@ public class Transfer
         return resource.getPath();
     }
 
+    public String getStoragePath()
+    {
+        return provider.getStoragePath( resource );
+    }
+
     public ConcreteResource getResource()
     {
         return resource;
@@ -461,9 +466,7 @@ public class Transfer
             return null;
         }
 
-        final String generatedPath = provider.getGeneratedPath( resource );
-
-        final String named = generatedPath + extension;
+        final String named = getStoragePath() + extension;
 
         final Transfer tx = this;
         logger.debug( "Creating meta-transfer sibling for: {}",

--- a/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
+++ b/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
@@ -70,7 +70,7 @@ public interface CacheProvider
 
     String getFilePath( ConcreteResource resource );
 
-    default String getGeneratedPath(ConcreteResource resource){
+    default String getStoragePath( ConcreteResource resource){
         return resource.getPath();
     }
 

--- a/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
+++ b/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
@@ -15,6 +15,10 @@
  */
 package org.commonjava.maven.galley.spi.cache;
 
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.model.Transfer;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,9 +26,6 @@ import java.io.OutputStream;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-
-import org.commonjava.maven.galley.model.ConcreteResource;
-import org.commonjava.maven.galley.model.Transfer;
 
 public interface CacheProvider
 {
@@ -70,8 +71,14 @@ public interface CacheProvider
 
     String getFilePath( ConcreteResource resource );
 
-    default String getStoragePath( ConcreteResource resource){
+    default String getStoragePath( ConcreteResource resource )
+    {
         return resource.getPath();
+    }
+
+    default String getStoragePath( Location location, String path )
+    {
+        return path;
     }
 
     boolean delete( ConcreteResource resource )

--- a/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
+++ b/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
@@ -16,7 +16,6 @@
 package org.commonjava.maven.galley.spi.cache;
 
 import org.commonjava.maven.galley.model.ConcreteResource;
-import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.model.Transfer;
 
 import java.io.File;
@@ -74,11 +73,6 @@ public interface CacheProvider
     default String getStoragePath( ConcreteResource resource )
     {
         return resource.getPath();
-    }
-
-    default String getStoragePath( Location location, String path )
-    {
-        return path;
     }
 
     boolean delete( ConcreteResource resource )

--- a/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
+++ b/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
@@ -70,6 +70,10 @@ public interface CacheProvider
 
     String getFilePath( ConcreteResource resource );
 
+    default String getGeneratedPath(ConcreteResource resource){
+        return resource.getPath();
+    }
+
     boolean delete( ConcreteResource resource )
         throws IOException;
 

--- a/api/src/main/java/org/commonjava/maven/galley/spi/io/PathGenerator.java
+++ b/api/src/main/java/org/commonjava/maven/galley/spi/io/PathGenerator.java
@@ -20,4 +20,9 @@ import org.commonjava.maven.galley.model.ConcreteResource;
 public interface PathGenerator
 {
     String getFilePath( final ConcreteResource resource );
+
+    default String getPath( final ConcreteResource resource )
+    {
+        return resource.getPath();
+    }
 }

--- a/api/src/main/java/org/commonjava/maven/galley/spi/io/PathGenerator.java
+++ b/api/src/main/java/org/commonjava/maven/galley/spi/io/PathGenerator.java
@@ -16,7 +16,6 @@
 package org.commonjava.maven.galley.spi.io;
 
 import org.commonjava.maven.galley.model.ConcreteResource;
-import org.commonjava.maven.galley.model.Location;
 
 public interface PathGenerator
 {
@@ -25,9 +24,5 @@ public interface PathGenerator
     default String getPath( final ConcreteResource resource )
     {
         return resource.getPath();
-    }
-
-    default String getPath( final Location location, final String path ){
-        return path;
     }
 }

--- a/api/src/main/java/org/commonjava/maven/galley/spi/io/PathGenerator.java
+++ b/api/src/main/java/org/commonjava/maven/galley/spi/io/PathGenerator.java
@@ -16,6 +16,7 @@
 package org.commonjava.maven.galley.spi.io;
 
 import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Location;
 
 public interface PathGenerator
 {
@@ -24,5 +25,9 @@ public interface PathGenerator
     default String getPath( final ConcreteResource resource )
     {
         return resource.getPath();
+    }
+
+    default String getPath( final Location location, final String path ){
+        return path;
     }
 }

--- a/api/src/main/java/org/commonjava/maven/galley/util/TransferUtils.java
+++ b/api/src/main/java/org/commonjava/maven/galley/util/TransferUtils.java
@@ -43,7 +43,7 @@ public class TransferUtils
         {
             if ( !transfer.isDirectory() )
             {
-                final String path = transfer.getPath();
+                final String path = transfer.getStoragePath();
                 // pattern for "groupId path/(artifactId)/(version)/(filename)"
                 // where the filename starts with artifactId-version and is followed by - or .
                 //                final Pattern pattern = Pattern.compile( ".*/([^/]+)/([^/]+)/(\\1-\\2[-.][^/]+)$" );

--- a/caches/partyline/src/main/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProvider.java
+++ b/caches/partyline/src/main/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProvider.java
@@ -332,11 +332,6 @@ public class PartyLineCacheProvider
     }
 
     @Override
-    public String getStoragePath(final Location location, final String path){
-        return pathGenerator.getPath( location, path );
-    }
-
-    @Override
     public Transfer getTransfer( final ConcreteResource resource )
     {
         Transfer txfr = new Transfer( resource, this, fileEventManager, transferDecorator );

--- a/caches/partyline/src/main/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProvider.java
+++ b/caches/partyline/src/main/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProvider.java
@@ -332,6 +332,11 @@ public class PartyLineCacheProvider
     }
 
     @Override
+    public String getStoragePath(final Location location, final String path){
+        return pathGenerator.getPath( location, path );
+    }
+
+    @Override
     public Transfer getTransfer( final ConcreteResource resource )
     {
         Transfer txfr = new Transfer( resource, this, fileEventManager, transferDecorator );

--- a/caches/partyline/src/main/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProvider.java
+++ b/caches/partyline/src/main/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProvider.java
@@ -327,6 +327,11 @@ public class PartyLineCacheProvider
     }
 
     @Override
+    public String getGeneratedPath(final ConcreteResource resource){
+        return pathGenerator.getPath( resource );
+    }
+
+    @Override
     public Transfer getTransfer( final ConcreteResource resource )
     {
         Transfer txfr = new Transfer( resource, this, fileEventManager, transferDecorator );

--- a/caches/partyline/src/main/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProvider.java
+++ b/caches/partyline/src/main/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProvider.java
@@ -327,7 +327,7 @@ public class PartyLineCacheProvider
     }
 
     @Override
-    public String getGeneratedPath(final ConcreteResource resource){
+    public String getStoragePath( final ConcreteResource resource){
         return pathGenerator.getPath( resource );
     }
 

--- a/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
+++ b/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
@@ -21,12 +21,10 @@ import org.commonjava.cdi.util.weft.config.WeftConfig;
 import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProvider;
 import org.commonjava.maven.galley.config.TransportMetricConfig;
 import org.commonjava.maven.galley.filearc.FileTransportConfig;
-import org.commonjava.maven.galley.io.SpecialPathManagerImpl;
 import org.commonjava.maven.galley.io.TransferDecoratorManager;
 import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.spi.event.FileEventManager;
 import org.commonjava.maven.galley.spi.io.PathGenerator;
-import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.commonjava.maven.galley.spi.transport.LocationExpander;
 import org.commonjava.maven.galley.spi.transport.LocationResolver;
 import org.commonjava.maven.galley.spi.transport.TransportManager;
@@ -67,8 +65,6 @@ public class TestCDIProvider
     private WeftConfig weftConfig;
 
     private MetricRegistry metricRegistry;
-
-    private SpecialPathManager specialPathManager;
 
     private TransportMetricConfig transportMetricConfig = new TransportMetricConfig()
     {
@@ -125,8 +121,6 @@ public class TestCDIProvider
         metricRegistry = new MetricRegistry();
 
         weftConfig = new DefaultWeftConfig(  );
-
-        specialPathManager = new SpecialPathManagerImpl(  );
     }
 
     @PreDestroy
@@ -189,12 +183,5 @@ public class TestCDIProvider
     public TransportMetricConfig getTransportMetricConfig()
     {
         return transportMetricConfig;
-    }
-
-    @Produces
-    @Default
-    public SpecialPathManager getSpecialPathManager()
-    {
-        return specialPathManager;
     }
 }

--- a/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
+++ b/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
@@ -21,10 +21,12 @@ import org.commonjava.cdi.util.weft.config.WeftConfig;
 import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProvider;
 import org.commonjava.maven.galley.config.TransportMetricConfig;
 import org.commonjava.maven.galley.filearc.FileTransportConfig;
+import org.commonjava.maven.galley.io.SpecialPathManagerImpl;
 import org.commonjava.maven.galley.io.TransferDecoratorManager;
 import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.spi.event.FileEventManager;
 import org.commonjava.maven.galley.spi.io.PathGenerator;
+import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.commonjava.maven.galley.spi.transport.LocationExpander;
 import org.commonjava.maven.galley.spi.transport.LocationResolver;
 import org.commonjava.maven.galley.spi.transport.TransportManager;
@@ -65,6 +67,8 @@ public class TestCDIProvider
     private WeftConfig weftConfig;
 
     private MetricRegistry metricRegistry;
+
+    private SpecialPathManager specialPathManager;
 
     private TransportMetricConfig transportMetricConfig = new TransportMetricConfig()
     {
@@ -121,6 +125,8 @@ public class TestCDIProvider
         metricRegistry = new MetricRegistry();
 
         weftConfig = new DefaultWeftConfig(  );
+
+        specialPathManager = new SpecialPathManagerImpl(  );
     }
 
     @PreDestroy
@@ -183,5 +189,12 @@ public class TestCDIProvider
     public TransportMetricConfig getTransportMetricConfig()
     {
         return transportMetricConfig;
+    }
+
+    @Produces
+    @Default
+    public SpecialPathManager getSpecialPathManager()
+    {
+        return specialPathManager;
     }
 }

--- a/core/src/main/java/org/commonjava/maven/galley/io/SpecialPathManagerImpl.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/SpecialPathManagerImpl.java
@@ -158,7 +158,7 @@ public class SpecialPathManagerImpl
     {
         if ( transfer != null )
         {
-            return getSpecialPathInfo( transfer.getLocation(), transfer.getPath(), pkgType );
+            return getSpecialPathInfo( transfer.getLocation(), transfer.getStoragePath(), pkgType );
         }
 
         // TODO: Return SpecialPathConstants.DEFAULT_FILE or SpecialPathConstants.DEFAULT_DIR or something non-null?

--- a/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingTransferDecoratorTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingTransferDecoratorTest.java
@@ -52,7 +52,6 @@ import static org.commonjava.maven.galley.io.checksum.testutil.TestDecoratorAdvi
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -74,7 +73,7 @@ public class ChecksummingTransferDecoratorTest
             throws Exception
     {
         fixture.setDecorator( new TransferDecoratorManager(
-                        new ChecksummingTransferDecorator( Collections.<TransferOperation>emptySet(),
+                        new ChecksummingTransferDecorator( Collections.emptySet(),
                                                            new SpecialPathManagerImpl(), false, false, metadataConsumer,
                                                            new Md5GeneratorFactory() ) ) );
         fixture.initMissingComponents();


### PR DESCRIPTION
For npm case, the realpath of package metadata is decorated by PathGenerator. So we should add this logic in Transfer.getSiblingMeta.