### PR TITLE
Improve metrics for transfer decorator, attempt to improve latency

### DIFF
--- a/core/src/main/java/org/commonjava/maven/galley/io/ChecksummingTransferDecorator.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/ChecksummingTransferDecorator.java
@@ -15,7 +15,7 @@
  */
 package org.commonjava.maven.galley.io;
 
-import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.io.checksum.AbstractChecksumGenerator;
 import org.commonjava.maven.galley.io.checksum.AbstractChecksumGeneratorFactory;
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
 
 import static org.commonjava.maven.galley.io.DeprecatedChecksummingFilter.calculateWriteOperations;
 import static org.commonjava.maven.galley.io.checksum.ChecksummingDecoratorAdvisor.ChecksumAdvice.CALCULATE_AND_WRITE;
@@ -60,40 +61,40 @@ public final class ChecksummingTransferDecorator
 
     private final ChecksummingDecoratorAdvisor readerFilter;
 
-    private MetricRegistry metricRegistry;
-
     private final TransferMetadataConsumer consumer;
 
     private final Set<AbstractChecksumGeneratorFactory<?>> checksumFactories;
 
     private SpecialPathManager specialPathManager;
 
+    private Function<String, Timer.Context> timerProvider;
+
     public ChecksummingTransferDecorator( final ChecksummingDecoratorAdvisor readerFilter,
                                           final ChecksummingDecoratorAdvisor writerFilter,
-                                          SpecialPathManager specialPathManager, MetricRegistry metricRegistry,
+                                          SpecialPathManager specialPathManager, Function<String, Timer.Context> timerProvider,
                                           TransferMetadataConsumer consumer,
                                           Set<AbstractChecksumGeneratorFactory<?>> checksumFactories )
     {
         this.readerFilter = readerFilter;
         this.writerFilter = writerFilter;
         this.specialPathManager = specialPathManager;
-        this.metricRegistry = metricRegistry;
+        this.timerProvider = timerProvider == null ? (s)->null : timerProvider;
         this.consumer = consumer;
         this.checksumFactories = checksumFactories;
     }
 
     public ChecksummingTransferDecorator( final ChecksummingDecoratorAdvisor readerFilter,
                                           final ChecksummingDecoratorAdvisor writerFilter,
-                                          SpecialPathManager specialPathManager, MetricRegistry metricRegistry,
+                                          SpecialPathManager specialPathManager, Function<String, Timer.Context> timerProvider,
                                           TransferMetadataConsumer consumer,
                                           AbstractChecksumGeneratorFactory<?>... checksumFactories )
     {
-        this( readerFilter, writerFilter, specialPathManager, metricRegistry, consumer,
+        this( readerFilter, writerFilter, specialPathManager, timerProvider, consumer,
               new HashSet<>( Arrays.asList( checksumFactories ) ) );
     }
 
     /**
-     * @see #ChecksummingTransferDecorator(ChecksummingDecoratorAdvisor, ChecksummingDecoratorAdvisor, SpecialPathManager, MetricRegistry, TransferMetadataConsumer, Set)
+     * @see #ChecksummingTransferDecorator(ChecksummingDecoratorAdvisor, ChecksummingDecoratorAdvisor, SpecialPathManager, Function, TransferMetadataConsumer, Set)
      */
     @Deprecated
     public ChecksummingTransferDecorator( final Set<TransferOperation> writeChecksumFilesOn,
@@ -108,7 +109,7 @@ public final class ChecksummingTransferDecorator
     }
 
     /**
-     * @see #ChecksummingTransferDecorator(ChecksummingDecoratorAdvisor, ChecksummingDecoratorAdvisor, SpecialPathManager, MetricRegistry, TransferMetadataConsumer, Set)
+     * @see #ChecksummingTransferDecorator(ChecksummingDecoratorAdvisor, ChecksummingDecoratorAdvisor, SpecialPathManager, Function, TransferMetadataConsumer, Set)
      */
     @Deprecated
     public ChecksummingTransferDecorator( final Set<TransferOperation> writeChecksumFilesOn,
@@ -171,7 +172,7 @@ public final class ChecksummingTransferDecorator
             {
                 logger.trace( "Wrapping output stream to: {} for checksum generation.", transfer );
                 return new ChecksummingOutputStream( checksumFactories, stream, transfer, consumer,
-                                                     advice == CALCULATE_AND_WRITE, metricRegistry );
+                                                     advice == CALCULATE_AND_WRITE, timerProvider );
             }
         }
 
@@ -212,7 +213,7 @@ public final class ChecksummingTransferDecorator
             if ( advice != NO_DECORATE && ( consumer == null || consumer.needsMetadataFor( transfer ) ) )
             {
                 return new ChecksummingInputStream( checksumFactories, stream, transfer, consumer,
-                                                    advice == CALCULATE_AND_WRITE, metricRegistry );
+                                                    advice == CALCULATE_AND_WRITE, timerProvider );
             }
         }
 

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/AbstractChecksumGeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/AbstractChecksumGeneratorFactory.java
@@ -15,10 +15,11 @@
  */
 package org.commonjava.maven.galley.io.checksum;
 
-import java.io.IOException;
-
-import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import org.commonjava.maven.galley.model.Transfer;
+
+import java.io.IOException;
+import java.util.function.Function;
 
 public abstract class AbstractChecksumGeneratorFactory<T extends AbstractChecksumGenerator>
 {
@@ -36,14 +37,14 @@ public abstract class AbstractChecksumGeneratorFactory<T extends AbstractChecksu
     }
 
     public final T createGenerator( final Transfer transfer, boolean writeChecksumFiles,
-                                    final MetricRegistry metricRegistry )
+                                    final Function<String, Timer.Context> timerProvider )
             throws IOException
     {
-        return newGenerator( transfer, writeChecksumFiles, metricRegistry );
+        return newGenerator( transfer, writeChecksumFiles, timerProvider == null ? (s)->null : timerProvider );
     }
 
     protected abstract T newGenerator( Transfer transfer, boolean writeChecksumFiles,
-                                       final MetricRegistry metricRegistry )
+                                       final Function<String, Timer.Context> timerProvider )
         throws IOException;
 
 }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/AbstractChecksumGeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/AbstractChecksumGeneratorFactory.java
@@ -17,6 +17,7 @@ package org.commonjava.maven.galley.io.checksum;
 
 import java.io.IOException;
 
+import com.codahale.metrics.MetricRegistry;
 import org.commonjava.maven.galley.model.Transfer;
 
 public abstract class AbstractChecksumGeneratorFactory<T extends AbstractChecksumGenerator>
@@ -31,16 +32,18 @@ public abstract class AbstractChecksumGeneratorFactory<T extends AbstractChecksu
     public final T createGenerator( final Transfer transfer )
         throws IOException
     {
-        return createGenerator( transfer, true );
+        return createGenerator( transfer, true, null );
     }
 
-    public final T createGenerator( final Transfer transfer, boolean writeChecksumFiles )
+    public final T createGenerator( final Transfer transfer, boolean writeChecksumFiles,
+                                    final MetricRegistry metricRegistry )
             throws IOException
     {
-        return newGenerator( transfer, writeChecksumFiles );
+        return newGenerator( transfer, writeChecksumFiles, metricRegistry );
     }
 
-    protected abstract T newGenerator( Transfer transfer, boolean writeChecksumFiles )
+    protected abstract T newGenerator( Transfer transfer, boolean writeChecksumFiles,
+                                       final MetricRegistry metricRegistry )
         throws IOException;
 
 }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingInputStream.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingInputStream.java
@@ -15,7 +15,6 @@
  */
 package org.commonjava.maven.galley.io.checksum;
 
-import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import org.commonjava.maven.galley.model.Transfer;
 import org.slf4j.Logger;
@@ -28,6 +27,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 public final class ChecksummingInputStream
         extends FilterInputStream
@@ -47,23 +47,23 @@ public final class ChecksummingInputStream
 
     private boolean writeChecksumFiles;
 
-    private MetricRegistry metricRegistry;
+    private Function<String, Timer.Context> timerProvider;
 
     public ChecksummingInputStream( final Set<AbstractChecksumGeneratorFactory<?>> checksumFactories,
                                     final InputStream stream, final Transfer transfer,
                                     final TransferMetadataConsumer metadataConsumer, final boolean writeChecksumFiles,
-                                    final MetricRegistry metricRegistry )
+                                    final Function<String, Timer.Context> timerProvider )
             throws IOException
     {
         super( stream );
         this.transfer = transfer;
         this.metadataConsumer = metadataConsumer;
         this.writeChecksumFiles = writeChecksumFiles;
-        this.metricRegistry = metricRegistry;
+        this.timerProvider = timerProvider == null ? (s)->null : timerProvider;
         checksums = new HashSet<>();
         for ( final AbstractChecksumGeneratorFactory<?> factory : checksumFactories )
         {
-            checksums.add( factory.createGenerator( transfer, writeChecksumFiles, metricRegistry ) );
+            checksums.add( factory.createGenerator( transfer, writeChecksumFiles, timerProvider ) );
         }
     }
 
@@ -71,7 +71,7 @@ public final class ChecksummingInputStream
     public void close()
             throws IOException
     {
-        Timer.Context closeTimer = metricRegistry == null ? null : metricRegistry.timer( CHECKSUM_CLOSE ).time();
+        Timer.Context closeTimer = timerProvider.apply( CHECKSUM_CLOSE );
         try
         {
             logger.trace( "START CLOSE: {}", transfer );

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingInputStream.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingInputStream.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2013 Red Hat, Inc. (nos-devel@redhat.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,8 @@
  */
 package org.commonjava.maven.galley.io.checksum;
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import org.commonjava.maven.galley.model.Transfer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +33,8 @@ public final class ChecksummingInputStream
         extends FilterInputStream
 {
 
+    private static final String CHECKSUM_CLOSE = "io.checksum.in.close";
+
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     private final Set<AbstractChecksumGenerator> checksums;
@@ -43,19 +47,23 @@ public final class ChecksummingInputStream
 
     private boolean writeChecksumFiles;
 
+    private MetricRegistry metricRegistry;
+
     public ChecksummingInputStream( final Set<AbstractChecksumGeneratorFactory<?>> checksumFactories,
                                     final InputStream stream, final Transfer transfer,
-                                    final TransferMetadataConsumer metadataConsumer, final boolean writeChecksumFiles )
+                                    final TransferMetadataConsumer metadataConsumer, final boolean writeChecksumFiles,
+                                    final MetricRegistry metricRegistry )
             throws IOException
     {
         super( stream );
         this.transfer = transfer;
         this.metadataConsumer = metadataConsumer;
         this.writeChecksumFiles = writeChecksumFiles;
+        this.metricRegistry = metricRegistry;
         checksums = new HashSet<>();
         for ( final AbstractChecksumGeneratorFactory<?> factory : checksumFactories )
         {
-            checksums.add( factory.createGenerator( transfer, writeChecksumFiles ) );
+            checksums.add( factory.createGenerator( transfer, writeChecksumFiles, metricRegistry ) );
         }
     }
 
@@ -63,10 +71,12 @@ public final class ChecksummingInputStream
     public void close()
             throws IOException
     {
+        Timer.Context closeTimer = metricRegistry == null ? null : metricRegistry.timer( CHECKSUM_CLOSE ).time();
         try
         {
             logger.trace( "START CLOSE: {}", transfer );
-            logger.trace( "Read done: {} in: {}. Now, creating checksums.", transfer.getPath(), transfer.getLocation() );
+            logger.trace( "Read done: {} in: {}. Now, creating checksums.", transfer.getPath(),
+                          transfer.getLocation() );
             Map<ContentDigest, String> hexDigests = new HashMap<>();
             for ( final AbstractChecksumGenerator checksum : checksums )
             {
@@ -87,10 +97,14 @@ public final class ChecksummingInputStream
             {
                 logger.trace( "No metadata consumer. NOT adding metadata." );
             }
-
         }
         finally
         {
+            if ( closeTimer != null )
+            {
+                closeTimer.stop();
+            }
+
             // NOTE: We close the main stream LAST, in case it's holding a file (or other) lock. This allows us to
             // finish out tasks BEFORE releasing that lock.
             super.close();
@@ -103,29 +117,28 @@ public final class ChecksummingInputStream
      *
      * NOTE: It's not enough to override {@link FilterInputStream#read()}. This method is NOT called by
      * {@link FilterInputStream#read(byte[], int, int)}, so you MUST override both to get consistent behavior.
-
      * @throws IOException in case of nested read error
      */
     @Override
     public int read()
             throws IOException
     {
-//        logger.trace( "READ: {}", transfer );
+        //        logger.trace( "READ: {}", transfer );
         int data = super.read();
         logger.trace( "{} input", data );
         if ( data > -1 )
         {
             size++;
-//            logger.trace( "Updating with: {} (raw: {})", ( (byte) data & 0xff ), data );
+            //            logger.trace( "Updating with: {} (raw: {})", ( (byte) data & 0xff ), data );
             for ( final AbstractChecksumGenerator checksum : checksums )
             {
                 checksum.update( (byte) data );
             }
         }
-//        else
-//        {
-//            logger.trace( "READ: <EOF>" );
-//        }
+        //        else
+        //        {
+        //            logger.trace( "READ: <EOF>" );
+        //        }
 
         return data;
     }
@@ -135,7 +148,6 @@ public final class ChecksummingInputStream
      *
      * NOTE: If you override {@link FilterInputStream#read(byte[])} as well as this method, and you call super.read(), you will
      * get DUPLICATE behavior (twice the effect) because this method DOES call {@link FilterInputStream#read(byte[], int, int)}.
-
      * @throws IOException in case of nested read error
      */
     @Override
@@ -155,7 +167,7 @@ public final class ChecksummingInputStream
         }
 
         size += read;
-//        logger.trace( "Updating with [buffer of size: {}]", read );
+        //        logger.trace( "Updating with [buffer of size: {}]", read );
         for ( final AbstractChecksumGenerator checksum : checksums )
         {
             for ( int i = off; i < off + read; i++ )

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Md5GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Md5GeneratorFactory.java
@@ -15,11 +15,12 @@
  */
 package org.commonjava.maven.galley.io.checksum;
 
-import java.io.IOException;
-
-import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import org.commonjava.maven.galley.io.checksum.Md5GeneratorFactory.Md5Generator;
 import org.commonjava.maven.galley.model.Transfer;
+
+import java.io.IOException;
+import java.util.function.Function;
 
 public final class Md5GeneratorFactory
     extends AbstractChecksumGeneratorFactory<Md5Generator>
@@ -31,10 +32,10 @@ public final class Md5GeneratorFactory
 
     @Override
     protected Md5Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile,
-                                         final MetricRegistry metricRegistry )
+                                         final Function<String, Timer.Context> timerProvider )
         throws IOException
     {
-        return new Md5Generator( transfer, writeChecksumFile, metricRegistry );
+        return new Md5Generator( transfer, writeChecksumFile, timerProvider );
     }
 
     public static final class Md5Generator
@@ -42,10 +43,10 @@ public final class Md5GeneratorFactory
     {
 
         protected Md5Generator( final Transfer transfer, final boolean writeChecksumFile,
-                                final MetricRegistry metricRegistry )
+                                final Function<String, Timer.Context> timerProvider )
             throws IOException
         {
-            super( transfer, ".md5", ContentDigest.MD5, writeChecksumFile, metricRegistry );
+            super( transfer, ".md5", ContentDigest.MD5, writeChecksumFile, timerProvider );
         }
 
     }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Md5GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Md5GeneratorFactory.java
@@ -17,6 +17,7 @@ package org.commonjava.maven.galley.io.checksum;
 
 import java.io.IOException;
 
+import com.codahale.metrics.MetricRegistry;
 import org.commonjava.maven.galley.io.checksum.Md5GeneratorFactory.Md5Generator;
 import org.commonjava.maven.galley.model.Transfer;
 
@@ -29,20 +30,22 @@ public final class Md5GeneratorFactory
     }
 
     @Override
-    protected Md5Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile )
+    protected Md5Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile,
+                                         final MetricRegistry metricRegistry )
         throws IOException
     {
-        return new Md5Generator( transfer, writeChecksumFile );
+        return new Md5Generator( transfer, writeChecksumFile, metricRegistry );
     }
 
     public static final class Md5Generator
         extends AbstractChecksumGenerator
     {
 
-        protected Md5Generator( final Transfer transfer, final boolean writeChecksumFile )
+        protected Md5Generator( final Transfer transfer, final boolean writeChecksumFile,
+                                final MetricRegistry metricRegistry )
             throws IOException
         {
-            super( transfer, ".md5", ContentDigest.MD5, writeChecksumFile );
+            super( transfer, ".md5", ContentDigest.MD5, writeChecksumFile, metricRegistry );
         }
 
     }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha1GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha1GeneratorFactory.java
@@ -15,11 +15,12 @@
  */
 package org.commonjava.maven.galley.io.checksum;
 
-import java.io.IOException;
-
-import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import org.commonjava.maven.galley.io.checksum.Sha1GeneratorFactory.Sha1Generator;
 import org.commonjava.maven.galley.model.Transfer;
+
+import java.io.IOException;
+import java.util.function.Function;
 
 public final class Sha1GeneratorFactory
     extends AbstractChecksumGeneratorFactory<Sha1Generator>
@@ -31,10 +32,10 @@ public final class Sha1GeneratorFactory
 
     @Override
     protected Sha1Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile,
-                                          final MetricRegistry metricRegistry )
+                                          final Function<String, Timer.Context> timerProvider )
         throws IOException
     {
-        return new Sha1Generator( transfer, writeChecksumFile, metricRegistry );
+        return new Sha1Generator( transfer, writeChecksumFile, timerProvider );
     }
 
     public static final class Sha1Generator
@@ -42,10 +43,10 @@ public final class Sha1GeneratorFactory
     {
 
         protected Sha1Generator( final Transfer transfer, final boolean writeChecksumFile,
-                                 final MetricRegistry metricRegistry )
+                                 final Function<String, Timer.Context> timerProvider )
             throws IOException
         {
-            super( transfer, ".sha1", ContentDigest.SHA_1, writeChecksumFile, metricRegistry );
+            super( transfer, ".sha1", ContentDigest.SHA_1, writeChecksumFile, timerProvider );
         }
 
     }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha1GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha1GeneratorFactory.java
@@ -17,6 +17,7 @@ package org.commonjava.maven.galley.io.checksum;
 
 import java.io.IOException;
 
+import com.codahale.metrics.MetricRegistry;
 import org.commonjava.maven.galley.io.checksum.Sha1GeneratorFactory.Sha1Generator;
 import org.commonjava.maven.galley.model.Transfer;
 
@@ -29,20 +30,22 @@ public final class Sha1GeneratorFactory
     }
 
     @Override
-    protected Sha1Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile )
+    protected Sha1Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile,
+                                          final MetricRegistry metricRegistry )
         throws IOException
     {
-        return new Sha1Generator( transfer, writeChecksumFile );
+        return new Sha1Generator( transfer, writeChecksumFile, metricRegistry );
     }
 
     public static final class Sha1Generator
         extends AbstractChecksumGenerator
     {
 
-        protected Sha1Generator( final Transfer transfer, final boolean writeChecksumFile )
+        protected Sha1Generator( final Transfer transfer, final boolean writeChecksumFile,
+                                 final MetricRegistry metricRegistry )
             throws IOException
         {
-            super( transfer, ".sha1", ContentDigest.SHA_1, writeChecksumFile );
+            super( transfer, ".sha1", ContentDigest.SHA_1, writeChecksumFile, metricRegistry );
         }
 
     }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha256GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha256GeneratorFactory.java
@@ -15,11 +15,12 @@
  */
 package org.commonjava.maven.galley.io.checksum;
 
-import java.io.IOException;
-
-import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import org.commonjava.maven.galley.io.checksum.Sha256GeneratorFactory.Sha256Generator;
 import org.commonjava.maven.galley.model.Transfer;
+
+import java.io.IOException;
+import java.util.function.Function;
 
 public final class Sha256GeneratorFactory
     extends AbstractChecksumGeneratorFactory<Sha256Generator>
@@ -31,10 +32,10 @@ public final class Sha256GeneratorFactory
 
     @Override
     protected Sha256Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile,
-                                            final MetricRegistry metricRegistry )
+                                            final Function<String, Timer.Context> timerProvider )
         throws IOException
     {
-        return new Sha256Generator( transfer, writeChecksumFile, metricRegistry );
+        return new Sha256Generator( transfer, writeChecksumFile, timerProvider );
     }
 
     public static final class Sha256Generator
@@ -42,10 +43,10 @@ public final class Sha256GeneratorFactory
     {
 
         protected Sha256Generator( final Transfer transfer, final boolean writeChecksumFile,
-                                   final MetricRegistry metricRegistry )
+                                   final Function<String, Timer.Context> timerProvider )
             throws IOException
         {
-            super( transfer, ".sha256", ContentDigest.SHA_256, writeChecksumFile, metricRegistry );
+            super( transfer, ".sha256", ContentDigest.SHA_256, writeChecksumFile, timerProvider );
         }
 
     }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha256GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha256GeneratorFactory.java
@@ -17,6 +17,7 @@ package org.commonjava.maven.galley.io.checksum;
 
 import java.io.IOException;
 
+import com.codahale.metrics.MetricRegistry;
 import org.commonjava.maven.galley.io.checksum.Sha256GeneratorFactory.Sha256Generator;
 import org.commonjava.maven.galley.model.Transfer;
 
@@ -29,20 +30,22 @@ public final class Sha256GeneratorFactory
     }
 
     @Override
-    protected Sha256Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile )
+    protected Sha256Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile,
+                                            final MetricRegistry metricRegistry )
         throws IOException
     {
-        return new Sha256Generator( transfer, writeChecksumFile );
+        return new Sha256Generator( transfer, writeChecksumFile, metricRegistry );
     }
 
     public static final class Sha256Generator
         extends AbstractChecksumGenerator
     {
 
-        protected Sha256Generator( final Transfer transfer, final boolean writeChecksumFile )
+        protected Sha256Generator( final Transfer transfer, final boolean writeChecksumFile,
+                                   final MetricRegistry metricRegistry )
             throws IOException
         {
-            super( transfer, ".sha256", ContentDigest.SHA_256, writeChecksumFile );
+            super( transfer, ".sha256", ContentDigest.SHA_256, writeChecksumFile, metricRegistry );
         }
 
     }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha384GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha384GeneratorFactory.java
@@ -15,11 +15,12 @@
  */
 package org.commonjava.maven.galley.io.checksum;
 
-import java.io.IOException;
-
-import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import org.commonjava.maven.galley.io.checksum.Sha384GeneratorFactory.Sha384Generator;
 import org.commonjava.maven.galley.model.Transfer;
+
+import java.io.IOException;
+import java.util.function.Function;
 
 import static org.commonjava.maven.galley.io.checksum.ContentDigest.SHA_384;
 
@@ -33,10 +34,10 @@ public final class Sha384GeneratorFactory
 
     @Override
     protected Sha384Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile,
-                                            final MetricRegistry metricRegistry )
+                                            final Function<String, Timer.Context> timerProvider )
         throws IOException
     {
-        return new Sha384Generator( transfer, writeChecksumFile, metricRegistry );
+        return new Sha384Generator( transfer, writeChecksumFile, timerProvider );
     }
 
     public static final class Sha384Generator
@@ -44,10 +45,10 @@ public final class Sha384GeneratorFactory
     {
 
         protected Sha384Generator( final Transfer transfer, final boolean writeChecksumFile,
-                                   final MetricRegistry metricRegistry )
+                                   final Function<String, Timer.Context> timerProvider )
             throws IOException
         {
-            super( transfer, ".sha384", SHA_384, writeChecksumFile, metricRegistry );
+            super( transfer, ".sha384", SHA_384, writeChecksumFile, timerProvider );
         }
 
     }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha384GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha384GeneratorFactory.java
@@ -17,6 +17,7 @@ package org.commonjava.maven.galley.io.checksum;
 
 import java.io.IOException;
 
+import com.codahale.metrics.MetricRegistry;
 import org.commonjava.maven.galley.io.checksum.Sha384GeneratorFactory.Sha384Generator;
 import org.commonjava.maven.galley.model.Transfer;
 
@@ -31,20 +32,22 @@ public final class Sha384GeneratorFactory
     }
 
     @Override
-    protected Sha384Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile )
+    protected Sha384Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile,
+                                            final MetricRegistry metricRegistry )
         throws IOException
     {
-        return new Sha384Generator( transfer, writeChecksumFile );
+        return new Sha384Generator( transfer, writeChecksumFile, metricRegistry );
     }
 
     public static final class Sha384Generator
         extends AbstractChecksumGenerator
     {
 
-        protected Sha384Generator( final Transfer transfer, final boolean writeChecksumFile )
+        protected Sha384Generator( final Transfer transfer, final boolean writeChecksumFile,
+                                   final MetricRegistry metricRegistry )
             throws IOException
         {
-            super( transfer, ".sha384", SHA_384, writeChecksumFile );
+            super( transfer, ".sha384", SHA_384, writeChecksumFile, metricRegistry );
         }
 
     }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha512GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha512GeneratorFactory.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2013 Red Hat, Inc. (nos-devel@redhat.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,15 +15,16 @@
  */
 package org.commonjava.maven.galley.io.checksum;
 
-import java.io.IOException;
-
+import com.codahale.metrics.MetricRegistry;
 import org.commonjava.maven.galley.io.checksum.Sha512GeneratorFactory.Sha512Generator;
 import org.commonjava.maven.galley.model.Transfer;
+
+import java.io.IOException;
 
 import static org.commonjava.maven.galley.io.checksum.ContentDigest.SHA_512;
 
 public final class Sha512GeneratorFactory
-    extends AbstractChecksumGeneratorFactory<Sha512Generator>
+        extends AbstractChecksumGeneratorFactory<Sha512Generator>
 {
 
     public Sha512GeneratorFactory()
@@ -31,20 +32,22 @@ public final class Sha512GeneratorFactory
     }
 
     @Override
-    protected Sha512Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile )
-        throws IOException
+    protected Sha512Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile,
+                                            final MetricRegistry metricRegistry )
+            throws IOException
     {
-        return new Sha512Generator( transfer, writeChecksumFile );
+        return new Sha512Generator( transfer, writeChecksumFile, metricRegistry );
     }
 
     public static final class Sha512Generator
-        extends AbstractChecksumGenerator
+            extends AbstractChecksumGenerator
     {
 
-        protected Sha512Generator( final Transfer transfer, final boolean writeChecksumFile )
-            throws IOException
+        protected Sha512Generator( final Transfer transfer, final boolean writeChecksumFile,
+                                   final MetricRegistry metricRegistry )
+                throws IOException
         {
-            super( transfer, ".sha512", SHA_512, writeChecksumFile );
+            super( transfer, ".sha512", SHA_512, writeChecksumFile, metricRegistry );
         }
 
     }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha512GeneratorFactory.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/Sha512GeneratorFactory.java
@@ -15,11 +15,12 @@
  */
 package org.commonjava.maven.galley.io.checksum;
 
-import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import org.commonjava.maven.galley.io.checksum.Sha512GeneratorFactory.Sha512Generator;
 import org.commonjava.maven.galley.model.Transfer;
 
 import java.io.IOException;
+import java.util.function.Function;
 
 import static org.commonjava.maven.galley.io.checksum.ContentDigest.SHA_512;
 
@@ -33,10 +34,10 @@ public final class Sha512GeneratorFactory
 
     @Override
     protected Sha512Generator newGenerator( final Transfer transfer, final boolean writeChecksumFile,
-                                            final MetricRegistry metricRegistry )
+                                            final Function<String, Timer.Context> timerProvider )
             throws IOException
     {
-        return new Sha512Generator( transfer, writeChecksumFile, metricRegistry );
+        return new Sha512Generator( transfer, writeChecksumFile, timerProvider );
     }
 
     public static final class Sha512Generator
@@ -44,10 +45,10 @@ public final class Sha512GeneratorFactory
     {
 
         protected Sha512Generator( final Transfer transfer, final boolean writeChecksumFile,
-                                   final MetricRegistry metricRegistry )
+                                   final Function<String, Timer.Context> timerProvider )
                 throws IOException
         {
-            super( transfer, ".sha512", SHA_512, writeChecksumFile, metricRegistry );
+            super( transfer, ".sha512", SHA_512, writeChecksumFile, timerProvider );
         }
 
     }

--- a/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingInputStreamTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingInputStreamTest.java
@@ -81,7 +81,7 @@ public class ChecksummingInputStreamTest
         {
             stream = new ChecksummingInputStream( new HashSet<AbstractChecksumGeneratorFactory<?>>(
                     Arrays.asList( new Md5GeneratorFactory(), new Sha1GeneratorFactory(),
-                                   new Sha256GeneratorFactory() ) ), is, txfr, testConsumer, true );
+                                   new Sha256GeneratorFactory() ) ), is, txfr, testConsumer, true, null );
 
             logger.debug( "Reading stream with {} bytes", data.length );
             byte[] resultData = IOUtils.toByteArray( stream );

--- a/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStreamTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStreamTest.java
@@ -75,7 +75,7 @@ public class ChecksummingOutputStreamTest
         {
             stream = new ChecksummingOutputStream( new HashSet<AbstractChecksumGeneratorFactory<?>>(
                     Arrays.asList( new Md5GeneratorFactory(), new Sha1GeneratorFactory(),
-                                   new Sha256GeneratorFactory() ) ), os, txfr, testConsumer, true );
+                                   new Sha256GeneratorFactory() ) ), os, txfr, testConsumer, true, null );
 
             stream.write( data );
         }

--- a/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingTransferDecoratorTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingTransferDecoratorTest.java
@@ -46,6 +46,7 @@ import java.util.Map;
 
 import static java.lang.Boolean.TRUE;
 import static org.apache.commons.codec.digest.DigestUtils.md5Hex;
+import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.commonjava.maven.galley.io.ChecksummingTransferDecorator.FORCE_CHECKSUM;
 import static org.commonjava.maven.galley.io.checksum.ContentDigest.MD5;
 import static org.commonjava.maven.galley.io.checksum.testutil.TestDecoratorAdvisor.DO_CHECKSUMS;
@@ -142,14 +143,23 @@ public class ChecksummingTransferDecoratorTest
 
         logger.info( "Opening transfer input stream" );
         EventMetadata forceEventMetadata = new EventMetadata();
-        try (InputStream stream = txfr.openInputStream( false, forceEventMetadata ))
+        InputStream stream = null;
+        try
         {
+            stream = txfr.openInputStream( false, forceEventMetadata );
             logger.info( "Reading stream" );
             byte[] resultData = IOUtils.toByteArray( stream );
 
             logger.debug( "Result is {} bytes", resultData.length );
 
             assertThat( Arrays.equals( resultData, data ), equalTo( true ) );
+        }
+        finally
+        {
+//            if ( stream != null )
+//            {
+                closeQuietly( stream );
+//            }
         }
 
         logger.debug( "Verifying .md5 file is missing" );
@@ -212,14 +222,23 @@ public class ChecksummingTransferDecoratorTest
                              final boolean checksumFileExists, final boolean metadataConsumerContains )
             throws IOException
     {
-        try (InputStream stream = txfr.openInputStream( false, em ))
+        InputStream stream = null;
+        try
         {
+            stream = txfr.openInputStream( false, em );
             logger.info( "Reading stream" );
             byte[] resultData = IOUtils.toByteArray( stream );
 
             logger.debug( "Result is {} bytes", resultData.length );
 
             assertThat( Arrays.equals( resultData, data ), equalTo( true ) );
+        }
+        finally
+        {
+//            if ( stream != null )
+//            {
+                closeQuietly( stream );
+//            }
         }
 
         logger.debug( "Verifying .md5 file is {}", checksumFileExists ? "available" : "misssing" );

--- a/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingTransferDecoratorTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingTransferDecoratorTest.java
@@ -170,7 +170,7 @@ public class ChecksummingTransferDecoratorTest
         fixture.setDecorator( new TransferDecoratorManager(
                         new ChecksummingTransferDecorator( new TestDecoratorAdvisor(),
                                                            new DisabledChecksummingDecoratorAdvisor(),
-                                                           new SpecialPathManagerImpl(), metadataConsumer,
+                                                           new SpecialPathManagerImpl(), null, metadataConsumer,
                                                            new Md5GeneratorFactory() ) ) );
         fixture.initMissingComponents();
         fixture.getCache().startReporting();

--- a/core/src/test/java/org/commonjava/maven/galley/io/checksum/Md5GeneratorFactoryTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/io/checksum/Md5GeneratorFactoryTest.java
@@ -63,7 +63,7 @@ public class Md5GeneratorFactoryTest
 
         final Md5GeneratorFactory factory = new Md5GeneratorFactory();
 
-        final Md5Generator generator = factory.newGenerator( txfr, true );
+        final Md5Generator generator = factory.newGenerator( txfr, true, null );
         generator.update( data );
         generator.write();
 

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/UploadMetadataGenTransferDecorator.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/UploadMetadataGenTransferDecorator.java
@@ -15,6 +15,8 @@
  */
 package org.commonjava.maven.galley.transport.htcli;
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
@@ -38,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEADERS;
+import static org.commonjava.maven.galley.transport.htcli.model.HttpExchangeMetadata.FILE_EXTENSION;
 
 /**
  * This TransferDecorator is used to generate http-metadata.json when uploading artifacts. It will use {@link EventMetadata}
@@ -49,13 +52,19 @@ import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEA
 public class UploadMetadataGenTransferDecorator
         extends AbstractTransferDecorator
 {
+    private static final String HTTP_METADATA_WRITE = "io.http-metadata.write";
+    private static final String HTTP_METADATA_WRITE_OPEN = HTTP_METADATA_WRITE + ".open";
+
     private static final Logger logger = LoggerFactory.getLogger( UploadMetadataGenTransferDecorator.class );
 
     private SpecialPathManager specialPathManager;
 
-    public UploadMetadataGenTransferDecorator( SpecialPathManager specialPathManager )
+    private MetricRegistry metricRegistry;
+
+    public UploadMetadataGenTransferDecorator( SpecialPathManager specialPathManager, MetricRegistry metricRegistry )
     {
         this.specialPathManager = specialPathManager;
+        this.metricRegistry = metricRegistry;
     }
 
     @Override
@@ -63,6 +72,11 @@ public class UploadMetadataGenTransferDecorator
                                        EventMetadata metadata )
             throws IOException
     {
+        if ( transfer.getPath().endsWith( FILE_EXTENSION ) )
+        {
+            return super.decorateWrite( stream, transfer, op, metadata );
+        }
+
         final SpecialPathInfo specialPathInfo = specialPathManager.getSpecialPathInfo( transfer, metadata.getPackageType() );
 
         final Boolean isMetadata = specialPathInfo != null && specialPathInfo.isMetadata();
@@ -81,62 +95,70 @@ public class UploadMetadataGenTransferDecorator
 
     private void writeMetadata( final Transfer target, final ObjectMapper mapper, final Map<String, List<String>> requestHeaders )
     {
-        Transfer metaTxfr = target.getSiblingMeta( HttpExchangeMetadata.FILE_EXTENSION );
-        if ( metaTxfr == null )
-        {
-            if ( target.isDirectory() )
-            {
-                logger.trace( "DIRECTORY. Using HTTP exchange metadata file INSIDE directory called: {}", HttpExchangeMetadata.FILE_EXTENSION );
-                metaTxfr = target.getChild( HttpExchangeMetadata.FILE_EXTENSION );
-            }
-            else
-            {
-                logger.trace( "SKIP: Cannot retrieve HTTP exchange metadata Transfer instance for: {}", target );
-                return;
-            }
-        }
-
-        final HttpExchangeMetadata metadata = new HttpExchangeMetadataFromRequestHeader( requestHeaders );
-        OutputStream out = null;
+        Timer.Context writeTimer = metricRegistry == null ? null : metricRegistry.timer( HTTP_METADATA_WRITE ).time();
         try
         {
-            final Transfer finalMeta = metaTxfr;
-            out = metaTxfr.openOutputStream( TransferOperation.GENERATE, false );
-            logger.trace( "Writing HTTP exchange metadata:\n\n{}\n\n", new Object()
+            Transfer metaTxfr = target.getSiblingMeta( FILE_EXTENSION );
+            if ( metaTxfr == null )
             {
-                @Override
-                public String toString()
+                if ( target.isDirectory() )
                 {
-                    try
-                    {
-                        return mapper.writeValueAsString( metadata );
-                    }
-                    catch ( final JsonProcessingException e )
-                    {
-                        logger.warn( String.format("Failed to write HTTP exchange metadata: %s. Reason: %s", finalMeta, e.getMessage()), e );
-                    }
-
-                    return "ERROR RENDERING METADATA";
+                    logger.trace( "DIRECTORY. Using HTTP exchange metadata file INSIDE directory called: {}", FILE_EXTENSION );
+                    metaTxfr = target.getChild( FILE_EXTENSION );
                 }
-            } );
-
-            out.write( mapper.writeValueAsBytes( metadata ) );
-        }
-        catch ( final IOException e )
-        {
-            if ( logger.isTraceEnabled() )
-            {
-                logger.trace( String.format( "Failed to write metadata for HTTP exchange to: %s. Reason: %s", metaTxfr,
-                                             e.getMessage() ), e );
+                else
+                {
+                    logger.trace( "SKIP: Cannot retrieve HTTP exchange metadata Transfer instance for: {}", target );
+                    return;
+                }
             }
-            else
+
+            final HttpExchangeMetadata metadata = new HttpExchangeMetadataFromRequestHeader( requestHeaders );
+            final Transfer finalMeta = metaTxfr;
+
+            Timer.Context openTimer = metricRegistry == null ? null : metricRegistry.timer( HTTP_METADATA_WRITE ).time();
+            try(OutputStream out = metaTxfr.openOutputStream( TransferOperation.GENERATE, false ) )
             {
-                logger.warn( "Failed to write metadata for HTTP exchange to: {}. Reason: {}", metaTxfr, e.getMessage() );
+                openTimer.stop();
+                logger.trace( "Writing HTTP exchange metadata:\n\n{}\n\n", new Object()
+                {
+                    @Override
+                    public String toString()
+                    {
+                        try
+                        {
+                            return mapper.writeValueAsString( metadata );
+                        }
+                        catch ( final JsonProcessingException e )
+                        {
+                            logger.warn( String.format("Failed to write HTTP exchange metadata: %s. Reason: %s", finalMeta, e.getMessage()), e );
+                        }
+
+                        return "ERROR RENDERING METADATA";
+                    }
+                } );
+
+                mapper.writeValue( out, metadata );
+            }
+            catch ( final IOException e )
+            {
+                if ( logger.isTraceEnabled() )
+                {
+                    logger.trace( String.format( "Failed to write metadata for HTTP exchange to: %s. Reason: %s", metaTxfr,
+                                                 e.getMessage() ), e );
+                }
+                else
+                {
+                    logger.warn( "Failed to write metadata for HTTP exchange to: {}. Reason: {}", metaTxfr, e.getMessage() );
+                }
             }
         }
         finally
         {
-            IOUtils.closeQuietly( out );
+            if ( writeTimer != null )
+            {
+                writeTimer.stop();
+            }
         }
     }
 

--- a/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/UploadMetadataGenTransferDecoratorTest.java
+++ b/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/UploadMetadataGenTransferDecoratorTest.java
@@ -75,7 +75,7 @@ public class UploadMetadataGenTransferDecoratorTest
     {
         tempFolder = folder.newFolder( "cache" );
         final UploadMetadataGenTransferDecorator decorator =
-                new UploadMetadataGenTransferDecorator( specialPathManager );
+                new UploadMetadataGenTransferDecorator( specialPathManager, null );
         provider = new TestCacheProvider( tempFolder, events, new TransferDecoratorManager( decorator ) );
     }
 


### PR DESCRIPTION
This PR just attempts to reduce latency that might be due to lock collisions when writing http-metadata, and also attempts to improve the metrics reported for different transfer decorators / checksum generators. It doesn't really change much but just tries to improve visibility. I've tested all of these changes lightly in the staging environment.