### PR TITLE
Remove physical file when there is IOException

### DIFF
--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/core/FileBasedPhysicalStore.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/core/FileBasedPhysicalStore.java
@@ -51,4 +51,11 @@ public class FileBasedPhysicalStore implements PhysicalStore
         return new FileInputStream( new File( baseDir, storageFile ) );
     }
 
+    @Override
+    public boolean delete( FileInfo fileInfo )
+    {
+        File f = new File( baseDir, fileInfo.getFileStorage() );
+        return f.delete();
+    }
+
 }

--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/core/PathDBOutputStream.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/core/PathDBOutputStream.java
@@ -3,6 +3,7 @@ package org.commonjava.maven.galley.cache.pathmapped.core;
 import org.commonjava.maven.galley.cache.pathmapped.model.PathKey;
 import org.commonjava.maven.galley.cache.pathmapped.model.PathMap;
 import org.commonjava.maven.galley.cache.pathmapped.spi.PathDB;
+import org.commonjava.maven.galley.cache.pathmapped.spi.PhysicalStore;
 
 import java.io.FilterOutputStream;
 import java.io.IOException;
@@ -16,9 +17,13 @@ public class PathDBOutputStream
 {
     private final PathDB pathDB;
 
+    private final PhysicalStore physicalStore;
+
     private final String fileSystem;
 
     private final String path;
+
+    private final FileInfo fileInfo;
 
     private final String fileId;
 
@@ -26,12 +31,14 @@ public class PathDBOutputStream
 
     private int size;
 
-    public PathDBOutputStream( PathDB pathDB, String fileSystem, String path, FileInfo fileInfo, OutputStream out )
+    public PathDBOutputStream( PathDB pathDB, PhysicalStore physicalStore, String fileSystem, String path, FileInfo fileInfo, OutputStream out )
     {
         super( out );
         this.pathDB = pathDB;
+        this.physicalStore = physicalStore;
         this.fileSystem = fileSystem;
         this.path = path;
+        this.fileInfo = fileInfo;
         this.fileId = fileInfo.getFileId();
         this.fileStorage = fileInfo.getFileStorage();
     }
@@ -39,21 +46,29 @@ public class PathDBOutputStream
     @Override
     public void write( int b ) throws IOException
     {
-        super.write( b );
-        size += 1;
+        try
+        {
+            super.write( b );
+            size += 1;
+        }
+        catch ( IOException e )
+        {
+            // the generated physical file should be deleted immediately
+            physicalStore.delete( fileInfo );
+            throw e;
+        }
     }
 
     @Override
     public void close() throws IOException
     {
+        super.close();
         PathMap pathMap = new PathMap();
-
         pathMap.setPathKey( getPathKey( fileSystem, path ) );
         pathMap.setCreation( new Date() );
         pathMap.setFileId( fileId );
         pathMap.setFileStorage( fileStorage );
         pathMap.setSize( size );
-
         pathDB.insert( pathMap );
     }
 }

--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/core/PathMappedFileManager.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/core/PathMappedFileManager.java
@@ -46,7 +46,8 @@ public class PathMappedFileManager
     public OutputStream openOutputStream( String fileSystem, String path ) throws IOException
     {
         FileInfo fileInfo = physicalStore.getFileInfo( fileSystem, path );
-        return new PathDBOutputStream( pathDB, fileSystem, path, fileInfo, physicalStore.getOutputStream( fileInfo ) );
+        return new PathDBOutputStream( pathDB, physicalStore, fileSystem, path, fileInfo,
+                                       physicalStore.getOutputStream( fileInfo ) );
     }
 
     public boolean delete( String fileSystem, String path )

--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/spi/PhysicalStore.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/spi/PhysicalStore.java
@@ -13,4 +13,6 @@ public interface PhysicalStore
     OutputStream getOutputStream( FileInfo fileInfo ) throws IOException;
 
     InputStream getInputStream( String storageFile ) throws IOException;
+
+    boolean delete( FileInfo fileInfo );
 }


### PR DESCRIPTION
It is for NOS-2014 - If a caller opens a new OutputStream to write a file, and then there is an IOException while writing the file, the generated physical file should be deleted/marked for deletion immediately