### PR TITLE
Wrap use of FilterInput(Output)Stream with idempotent close()

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/util/AtomicFileOutputStreamWrapper.java
+++ b/api/src/main/java/org/commonjava/maven/galley/util/AtomicFileOutputStreamWrapper.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class AtomicFileOutputStreamWrapper
-    extends FilterOutputStream
+    extends IdempotentCloseOutputStream
 {
 
     public static abstract class AtomicStreamCallbacks

--- a/api/src/main/java/org/commonjava/maven/galley/util/IdempotentCloseOutputStream.java
+++ b/api/src/main/java/org/commonjava/maven/galley/util/IdempotentCloseOutputStream.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.maven.galley.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class IdempotentCloseOutputStream
+        extends FilterOutputStream
+{
+    private AtomicBoolean closed = new AtomicBoolean( false );
+
+    protected IdempotentCloseOutputStream( final OutputStream out )
+    {
+        super( out );
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        if ( !closed.getAndSet( true ) ) // if previous value was false, skip this and log it!
+        {
+            logger.trace( "Closing: {}", this );
+            super.close();
+        }
+        else
+        {
+            logger.warn( "Preventing duplicate close() call to: {}", this );
+        }
+    }
+}

--- a/api/src/main/java/org/commonjava/maven/galley/util/TransferOutputStream.java
+++ b/api/src/main/java/org/commonjava/maven/galley/util/TransferOutputStream.java
@@ -22,9 +22,11 @@ import java.io.OutputStream;
 import org.commonjava.maven.galley.event.FileStorageEvent;
 import org.commonjava.maven.galley.model.Transfer.TransferUnlocker;
 import org.commonjava.maven.galley.spi.event.FileEventManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TransferOutputStream
-    extends FilterOutputStream
+    extends IdempotentCloseOutputStream
 {
 
     private final TransferUnlocker unlocker;

--- a/core/src/main/java/org/commonjava/maven/galley/cache/FileCacheProvider.java
+++ b/core/src/main/java/org/commonjava/maven/galley/cache/FileCacheProvider.java
@@ -24,6 +24,7 @@ import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.maven.galley.spi.event.FileEventManager;
 import org.commonjava.maven.galley.spi.io.PathGenerator;
 import org.commonjava.maven.galley.util.AtomicFileOutputStreamWrapper;
+import org.commonjava.maven.galley.util.IdempotentCloseInputStream;
 import org.commonjava.maven.galley.util.PathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -416,7 +417,7 @@ public class FileCacheProvider
     }
 
     private class UnlockInputStream
-            extends FilterInputStream
+            extends IdempotentCloseInputStream
     {
         private final ConcreteResource resource;
 

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingInputStream.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingInputStream.java
@@ -17,6 +17,7 @@ package org.commonjava.maven.galley.io.checksum;
 
 import com.codahale.metrics.Timer;
 import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.util.IdempotentCloseInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 public final class ChecksummingInputStream
-        extends FilterInputStream
+        extends IdempotentCloseInputStream
 {
 
     private static final String CHECKSUM_CLOSE = "io.checksum.in.close";

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStream.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStream.java
@@ -17,6 +17,7 @@ package org.commonjava.maven.galley.io.checksum;
 
 import com.codahale.metrics.Timer;
 import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.util.IdempotentCloseOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 public final class ChecksummingOutputStream
-        extends FilterOutputStream
+        extends IdempotentCloseOutputStream
 {
 
     private static final String CHECKSUM_CLOSE = "io.checksum.out.close";

--- a/core/src/main/java/org/commonjava/maven/galley/io/nocache/NoCacheInputStream.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/nocache/NoCacheInputStream.java
@@ -16,6 +16,7 @@
 package org.commonjava.maven.galley.io.nocache;
 
 import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.util.IdempotentCloseInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +30,7 @@ import static org.commonjava.maven.galley.io.SpecialPathConstants.HTTP_METADATA_
  * Created by ruhan on 4/25/17.
  */
 public class NoCacheInputStream
-                extends FilterInputStream
+        extends IdempotentCloseInputStream
 {
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/UploadMetadataGenTransferDecorator.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/UploadMetadataGenTransferDecorator.java
@@ -26,6 +26,7 @@ import org.commonjava.maven.galley.model.TransferOperation;
 import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.commonjava.maven.galley.transport.htcli.model.HttpExchangeMetadata;
 import org.commonjava.maven.galley.transport.htcli.model.HttpExchangeMetadataFromRequestHeader;
+import org.commonjava.maven.galley.util.IdempotentCloseOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,7 +123,7 @@ public class UploadMetadataGenTransferDecorator
 
             Timer.Context openTimer = timerProvider.apply( HTTP_METADATA_WRITE_OPEN );
             logger.debug( "http-metadata open-timer is: {}", openTimer );
-            try(OutputStream out = metaTxfr.openOutputStream( TransferOperation.GENERATE, false ) )
+            try( OutputStream out = metaTxfr.openOutputStream( TransferOperation.GENERATE, false ) )
             {
                 if ( openTimer != null )
                 {
@@ -172,7 +173,7 @@ public class UploadMetadataGenTransferDecorator
     }
 
     private class HttpMetadataWrapperOutputStream
-            extends FilterOutputStream
+            extends IdempotentCloseOutputStream
     {
         private final Transfer transfer;
 


### PR DESCRIPTION
The new IdempotentCloseInput/OutputStream classes record when a stream is closed and prevent it from being closed twice. If this happens, the event is logged.