### PR TITLE
Add path generator for mapped-path cache provider

### DIFF
--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
@@ -23,6 +23,7 @@ import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.maven.galley.spi.event.FileEventManager;
+import org.commonjava.maven.galley.spi.io.PathGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,13 +58,16 @@ public class PathMappedCacheProvider
 
     private ScheduledExecutorService deleteExecutor;
 
+    private PathGenerator pathGenerator;
+
     private List<Transfer> toDelete = Collections.synchronizedList( new ArrayList<>() );
 
     public PathMappedCacheProvider( final File cacheBasedir,
                                     final FileEventManager fileEventManager,
                                     final TransferDecoratorManager transferDecorator,
                                     final ScheduledExecutorService deleteExecutor,
-                                    final PathMappedFileManager fileManager )
+                                    final PathMappedFileManager fileManager,
+                                    final PathGenerator pathGenerator)
     {
         this.fileEventManager = fileEventManager;
         this.transferDecorator = transferDecorator;
@@ -74,6 +78,7 @@ public class PathMappedCacheProvider
                         deleteExecutor == null ? Executors.newScheduledThreadPool( corePoolSize ) : deleteExecutor;
         this.fileManager = fileManager;
 
+        this.pathGenerator = pathGenerator;
         if ( deleteExecutor instanceof ThreadPoolExecutor )
         {
             corePoolSize = ( (ThreadPoolExecutor) deleteExecutor ).getPoolSize();
@@ -143,7 +148,8 @@ public class PathMappedCacheProvider
     {
         Location loc = resource.getLocation();
         String fileSystem = loc.getName();
-        return fileManager.openOutputStream( fileSystem, resource.getPath() );
+        String realPath = pathGenerator.getPath( resource );
+        return fileManager.openOutputStream( fileSystem, realPath );
     }
 
     @Override
@@ -224,7 +230,8 @@ public class PathMappedCacheProvider
     {
         Location loc = resource.getLocation();
         String fileSystem = loc.getName();
-        return fileManager.getFileStoragePath( fileSystem, resource.getPath() );
+        String realPath = pathGenerator.getPath(resource);
+        return fileManager.getFileStoragePath( fileSystem, realPath );
     }
 
     @Override

--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderFactory.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderFactory.java
@@ -62,7 +62,7 @@ public class PathMappedCacheProviderFactory
                                                     new PathMappedFileManager( config,
                                                                                new CassandraPathDB( config ),
                                                                                new FileBasedPhysicalStore(
-                                                                                               cacheDir ) ) );
+                                                                                               cacheDir ) ),pathGenerator );
         }
         return provider;
     }

--- a/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderCassandraTest.java
+++ b/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderCassandraTest.java
@@ -26,6 +26,7 @@ import org.commonjava.maven.galley.cache.pathmapped.core.PathMappedFileManager;
 import org.commonjava.maven.galley.cache.pathmapped.model.Reclaim;
 import org.commonjava.maven.galley.cache.testutil.TestFileEventManager;
 import org.commonjava.maven.galley.cache.testutil.TestTransferDecorator;
+import org.commonjava.maven.galley.io.HashedLocationPathGenerator;
 import org.commonjava.maven.galley.io.TransferDecoratorManager;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Location;
@@ -33,6 +34,7 @@ import org.commonjava.maven.galley.model.SimpleLocation;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.maven.galley.spi.event.FileEventManager;
+import org.commonjava.maven.galley.spi.io.PathGenerator;
 import org.commonjava.maven.galley.spi.io.TransferDecorator;
 import org.junit.After;
 import org.junit.Before;
@@ -96,13 +98,15 @@ public class PathMappedCacheProviderCassandraTest
         final FileEventManager events = new TestFileEventManager();
         final TransferDecorator decorator = new TestTransferDecorator();
 
+        final PathGenerator pathgen = new HashedLocationPathGenerator();
+
         File baseDir = temp.newFolder();
         pathDB = new CassandraPathDB( config );
         fileManager = new PathMappedFileManager( new DefaultPathMappedStorageConfig(), pathDB,
                                                  new FileBasedPhysicalStore( baseDir ) );
         provider = new PathMappedCacheProvider( baseDir, events, new TransferDecoratorManager( decorator ),
                                                 Executors.newScheduledThreadPool( 2 ),
-                                                fileManager );
+                                                fileManager, pathgen );
     }
 
     @After

--- a/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderTest.java
+++ b/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderTest.java
@@ -22,12 +22,14 @@ import org.commonjava.maven.galley.cache.pathmapped.core.PathMappedFileManager;
 import org.commonjava.maven.galley.cache.pathmapped.jpa.JPAPathDB;
 import org.commonjava.maven.galley.cache.testutil.TestFileEventManager;
 import org.commonjava.maven.galley.cache.testutil.TestTransferDecorator;
+import org.commonjava.maven.galley.io.HashedLocationPathGenerator;
 import org.commonjava.maven.galley.io.TransferDecoratorManager;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.model.SimpleLocation;
 import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.maven.galley.spi.event.FileEventManager;
+import org.commonjava.maven.galley.spi.io.PathGenerator;
 import org.commonjava.maven.galley.spi.io.TransferDecorator;
 import org.junit.Before;
 import org.junit.Rule;
@@ -57,13 +59,14 @@ public class PathMappedCacheProviderTest
     {
         final FileEventManager events = new TestFileEventManager();
         final TransferDecorator decorator = new TestTransferDecorator();
+        final PathGenerator pathgen = new HashedLocationPathGenerator();
 
         File baseDir = temp.newFolder();
         provider = new PathMappedCacheProvider( baseDir, events, new TransferDecoratorManager( decorator ),
                                                 Executors.newScheduledThreadPool( 2 ),
                                                 new PathMappedFileManager( new DefaultPathMappedStorageConfig(),
                                                                            new JPAPathDB( "test" ),
-                                                                           new FileBasedPhysicalStore( baseDir ) ) );
+                                                                           new FileBasedPhysicalStore( baseDir ) ), pathgen );
     }
 
     @Override


### PR DESCRIPTION
We need path generator to determine the real path from outer system, for example, npm package.json when hit the root package path