### PR TITLE
Expose GC in case the caller wants to run it directly

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
+++ b/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
@@ -128,6 +128,11 @@ public interface CacheProvider
     {
         boolean isFileBased();
 
-        File getDetachedFile( ConcreteResource resource );
+        default File getDetachedFile( ConcreteResource resource ) { return null; }
+
+        /**
+         * Expose GC in case the caller wants to run it directly, especially in functional test
+         */
+        default void gc() {}
     }
 }

--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
@@ -101,6 +101,12 @@ public class PathMappedCacheProvider
     }
 
     @Override
+    public void gc()
+    {
+        fileManager.gc();
+    }
+
+    @Override
     public boolean isDirectory( final ConcreteResource resource )
     {
         return handleResource( resource, (f, p)-> fileManager.isDirectory( f, p ), "isDirectory" );


### PR DESCRIPTION
Expose GC because indy wants to run it directly in the functional tests. 