### PR TITLE
Add close() to cacheprovider so that the caller have a chance to clearup

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
+++ b/api/src/main/java/org/commonjava/maven/galley/spi/cache/CacheProvider.java
@@ -134,5 +134,7 @@ public interface CacheProvider
          * Expose GC in case the caller wants to run it directly, especially in functional test
          */
         default void gc() {}
+
+        default void close() {}
     }
 }

--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
@@ -107,6 +107,19 @@ public class PathMappedCacheProvider
     }
 
     @Override
+    public void close()
+    {
+        try
+        {
+            fileManager.close();
+        }
+        catch ( IOException e )
+        {
+            logger.warn( "Fail to close", e );
+        }
+    }
+
+    @Override
     public boolean isDirectory( final ConcreteResource resource )
     {
         return handleResource( resource, (f, p)-> fileManager.isDirectory( f, p ), "isDirectory" );


### PR DESCRIPTION
Add a close() to CacheProvider.AdminView so that the caller can do clean-up. 