### PR TITLE
Avoid to store the http-metadata file when the target is not found

### DIFF
--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/AbstractHttpJob.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/AbstractHttpJob.java
@@ -147,14 +147,20 @@ public abstract class AbstractHttpJob
             * and with a condition that it only runs on HEAD or GET. This would allow us to capture metadata on failed requests too,
             * which is critical for responding consistently to the user after a failed request is cached in the NFC.
             */
-            String method = request.getMethod();
-            if ( "GET".equalsIgnoreCase( method ) || "HEAD".equalsIgnoreCase( method ) )
+            final StatusLine line = response.getStatusLine();
+            final int sc = line.getStatusCode();
+            // Generate the file .http-metadata.json only if the target is not missing
+            if ( sc != 404 )
             {
-                Transfer target = getTransfer();
-                ObjectMapper mapper = getMetadataObjectMapper();
-                if ( target != null && mapper != null )
+                String method = request.getMethod();
+                if ( "GET".equalsIgnoreCase( method ) || "HEAD".equalsIgnoreCase( method ) )
                 {
-                    writeMetadata( target, mapper );
+                    Transfer target = getTransfer();
+                    ObjectMapper mapper = getMetadataObjectMapper();
+                    if ( target != null && mapper != null )
+                    {
+                        writeMetadata( target, mapper );
+                    }
                 }
             }
         }

--- a/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownloadTest.java
+++ b/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownloadTest.java
@@ -29,6 +29,7 @@ import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.spi.transport.DownloadJob;
 import org.commonjava.maven.galley.config.TransportMetricConfig;
+import org.commonjava.maven.galley.transport.htcli.model.HttpExchangeMetadata;
 import org.commonjava.maven.galley.transport.htcli.model.SimpleHttpLocation;
 import org.commonjava.maven.galley.transport.htcli.testutil.HttpTestFixture;
 import org.commonjava.test.http.expect.ExpectationHandler;
@@ -377,6 +378,8 @@ public class HttpDownloadTest
         assertThat( result, notNullValue() );
         assertThat( result.exists(), equalTo( false ) );
         assertThat( transfer.exists(), equalTo( false ) );
+        assertThat( transfer.getSiblingMeta( HttpExchangeMetadata.FILE_EXTENSION ).exists(), equalTo( false ) );
+        assertThat( result.getSiblingMeta( HttpExchangeMetadata.FILE_EXTENSION ).exists(), equalTo( false ) );
 
         final String path = fixture.getUrlPath( url );
 


### PR DESCRIPTION
Issue: https://projects.engineering.redhat.com/browse/NOSSUP-112