### PR TITLE
[path-mapped] expose PathMappedCacheProvider.pathMappedFileManager

### DIFF
--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
@@ -359,6 +359,11 @@ public class PathMappedCacheProvider
         fileManager.stopReporting();
     }
 
+    public PathMappedFileManager getPathMappedFileManager()
+    {
+        return fileManager;
+    }
+
     @FunctionalInterface
     interface PathMappedPathHandler<T>
     {


### PR DESCRIPTION
So the caller can use methods which are not in CacheProvider interface, e.g, recursive listing.