### PR TITLE
Update to pathmap 1.1

### DIFF
--- a/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderCassandraTest.java
+++ b/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderCassandraTest.java
@@ -44,6 +44,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
@@ -51,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 
+import static org.commonjava.maven.galley.cache.testutil.AssertUtil.assertThrows;
 import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.PROP_CASSANDRA_HOST;
 import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.PROP_CASSANDRA_KEYSPACE;
 import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.PROP_CASSANDRA_PORT;
@@ -154,8 +156,7 @@ public class PathMappedCacheProviderCassandraTest
         assertThat( result, equalTo( content ) );
 
         // source file should have been removed
-        InputStream src = provider.openInputStream( new ConcreteResource( loc, fname ) );
-        assertThat( src, equalTo( null ) );
+        assertThrows( IOException.class, () -> provider.openInputStream( new ConcreteResource( loc, fname ) ) );
     }
 
     @Test
@@ -176,8 +177,7 @@ public class PathMappedCacheProviderCassandraTest
 
         provider.delete( resource );
 
-        InputStream src = provider.openInputStream( resource );
-        assertThat( src, equalTo( null ) );
+        assertThrows( IOException.class, () -> provider.openInputStream( resource ) );
 
         Transfer transfer = provider.getTransfer( resource );
         assertThat( transfer, notNullValue() );

--- a/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderJPATest.java
+++ b/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderJPATest.java
@@ -38,12 +38,15 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.concurrent.Executors;
 
+import static org.commonjava.maven.galley.cache.testutil.AssertUtil.assertThrows;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class PathMappedCacheProviderJPATest
                 extends CacheProviderTCK
@@ -106,8 +109,7 @@ public class PathMappedCacheProviderJPATest
         assertThat( result, equalTo( content ) );
 
         // source file should have been removed
-        InputStream src = provider.openInputStream( new ConcreteResource( loc, fname ) );
-        assertThat( src, equalTo( null ) );
+        assertThrows( IOException.class, () -> provider.openInputStream( new ConcreteResource( loc, fname ) ) );
     }
 
 }

--- a/caches/tck/src/main/java/org/commonjava/maven/galley/cache/testutil/AssertUtil.java
+++ b/caches/tck/src/main/java/org/commonjava/maven/galley/cache/testutil/AssertUtil.java
@@ -1,0 +1,35 @@
+package org.commonjava.maven.galley.cache.testutil;
+
+import java.io.IOException;
+
+import static org.junit.Assert.fail;
+
+public class AssertUtil
+{
+    @FunctionalInterface
+    public interface CheckedFunction
+    {
+        void apply() throws IOException;
+    }
+
+    public static void assertThrows( Class exceptionClass, CheckedFunction o )
+    {
+        try
+        {
+            o.apply();
+            fail();
+        }
+        catch ( Exception e )
+        {
+            if ( exceptionClass.isInstance( e ) )
+            {
+                System.out.println( "Expected: " + e.getMessage() ); // ok
+            }
+            else
+            {
+                fail( "Expected: " + exceptionClass.getName() + ", but got " + e.getClass().getName() );
+            }
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <!--<undertowVersion>1.3.33.Final</undertowVersion>-->
     <atlasVersion>1.1.0</atlasVersion>
     <partylineVersion>1.16</partylineVersion>
-    <pathmappedStorageVersion>1.0</pathmappedStorageVersion>
+    <pathmappedStorageVersion>1.1</pathmappedStorageVersion>
     <weftVersion>1.14</weftVersion>
     <jhttpcVersion>1.9</jhttpcVersion>
     <infinispanVersion>9.4.7.Final</infinispanVersion>


### PR DESCRIPTION
This pr fix two tests because the openInputStream in path-map 1.1 throws IOException if file not found. In prev 1.0, it return null. 