### PR TITLE
Save transfer immutables

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/util/LocationUtils.java
+++ b/api/src/main/java/org/commonjava/maven/galley/util/LocationUtils.java
@@ -31,7 +31,6 @@ public final class LocationUtils
 
     public static int getTimeoutSeconds( final ConcreteResource resource )
     {
-        logger.debug( "Retrieving timeout from resource: {}", resource );
         return getTimeoutSeconds( resource.getLocation() );
     }
 
@@ -39,7 +38,7 @@ public final class LocationUtils
     {
         if ( logger.isDebugEnabled() )
         {
-            logger.debug( "Retrieving timeout from location: {}", location );
+            logger.debug( "Get timeoutSeconds of location: {}", location );
         }
 
         return location.getAttribute( Location.CONNECTION_TIMEOUT_SECONDS, Integer.class,


### PR DESCRIPTION
Some transfer properties are immutable. We can save them because they are called more than one times per request. And in case of path-mapped storage, each is one DB access.
I tested with Indy ftests and all passed.
I picked up some ftests and calculate the db access count, this fix reduces half of path-db accesses (50%). 
Full test result is in NOS-2441.