### PR TITLE
[NFC] Ignore the timeout exception when addMissing

### DIFF
--- a/core/src/main/java/org/commonjava/maven/galley/internal/xfer/DownloadHandler.java
+++ b/core/src/main/java/org/commonjava/maven/galley/internal/xfer/DownloadHandler.java
@@ -159,7 +159,7 @@ public class DownloadHandler
                         logger.debug( "NFC: Download error. Marking as missing: {}\nError was: {}", job.getError(),
                                       resource, job.getError().getMessage() );
                         
-                        if ( ! (job.getError() instanceof  TransferContentException ) )
+                        if ( ! (job.getError() instanceof  TransferContentException ) && ! (job.getError() instanceof TransferTimeoutException ) )
                         {
                             nfc.addMissing( resource );
                         }


### PR DESCRIPTION
I think we can ignore to put the target in NFC when it run into the TransferTimeoutException. Sometimes it failed at the first time and might success when retry that next time.  