### PR TITLE
Safe way to get test resource

### DIFF
--- a/maven/src/test/java/org/commonjava/maven/galley/maven/util/PomPeekTest.java
+++ b/maven/src/test/java/org/commonjava/maven/galley/maven/util/PomPeekTest.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
-
+import static org.junit.Assert.fail;
 
 public class PomPeekTest
 {
@@ -126,12 +126,11 @@ public class PomPeekTest
 
     public static File getResourceFile( final String path )
     {
-        final URL resource = Thread.currentThread()
-                                   .getContextClassLoader()
+        final URL resource = PomPeekTest.class.getClassLoader()
                                    .getResource( path );
         if ( resource == null )
         {
-            // fail( "Resource not found: " + path );
+            fail( "Resource not found: " + path );
         }
 
         return new File( resource.getPath() );


### PR DESCRIPTION
PomPeekTest failed on release automation job. I suspect the get resource failed for some reason.
https://jenkins-nos-automation.cloud.paas.psi.redhat.com/job/Release%20Automation/view/Library%20release/job/galley-release-master/5/console
This fix is safer. It is like what we did for loading indy api properties. 