### PR TITLE
Removed reliance on FilteredOutputStream write method calls. 

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/util/IdempotentCloseOutputStream.java
+++ b/api/src/main/java/org/commonjava/maven/galley/util/IdempotentCloseOutputStream.java
@@ -24,13 +24,15 @@ import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class IdempotentCloseOutputStream
-        extends FilterOutputStream
+        extends OutputStream
 {
     private AtomicBoolean closed = new AtomicBoolean( false );
 
+    final private OutputStream out;
+
     protected IdempotentCloseOutputStream( final OutputStream out )
     {
-        super( out );
+        this.out = out;
     }
 
     @Override
@@ -41,11 +43,23 @@ public class IdempotentCloseOutputStream
         if ( !closed.getAndSet( true ) ) // if previous value was false, skip this and log it!
         {
             logger.trace( "Closing: {}", this );
-            super.close();
+            out.close();
         }
         else
         {
             logger.warn( "Preventing duplicate close() call to: {}", this );
         }
+    }
+
+    @Override
+    public void write( byte b[], int off, int len )
+            throws IOException {
+        out.write( b, off, len);
+    }
+
+    @Override
+    public void write( int b )
+            throws IOException {
+        out.write( b );
     }
 }

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStream.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStream.java
@@ -130,4 +130,18 @@ public final class ChecksummingOutputStream
         }
     }
 
+    @Override
+    public void write (byte[] b, int off, int len)
+    throws IOException
+    {
+        if ((off | len | (b.length - (len + off)) | (off + len)) < 0)
+            throw new IndexOutOfBoundsException();
+
+        super.write( b, off, len );
+        size += len;
+        for ( final AbstractChecksumGenerator checksum : checksums )
+        {
+            checksum.update( b );
+        }
+    }
 }


### PR DESCRIPTION
This change allows a BufferedOutputStream to efficiently write to underlying stream.