### PR TITLE
Write sub array when necessary.

### DIFF
--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/AbstractChecksumGenerator.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/AbstractChecksumGenerator.java
@@ -92,6 +92,11 @@ public abstract class AbstractChecksumGenerator
         digester.update( data );
     }
 
+    public final void update( final byte[] data, final int offset, final int len )
+    {
+        digester.update( data, offset, len );
+    }
+
     public final void write()
             throws IOException
     {

--- a/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStream.java
+++ b/core/src/main/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStream.java
@@ -131,17 +131,14 @@ public final class ChecksummingOutputStream
     }
 
     @Override
-    public void write (byte[] b, int off, int len)
-    throws IOException
+    public void write ( byte[] b, int off, int len )
+            throws IOException
     {
-        if ((off | len | (b.length - (len + off)) | (off + len)) < 0)
-            throw new IndexOutOfBoundsException();
-
         super.write( b, off, len );
         size += len;
         for ( final AbstractChecksumGenerator checksum : checksums )
         {
-            checksum.update( b );
+            checksum.update( b, off, len );
         }
     }
 }


### PR DESCRIPTION
 This PR patches #339 to ensure the checksum is updated only with the intended array contents. It might be all or smaller quantity of array elements. The change caters for the smaller quantity case.