### PR TITLE
Make internal out protected for indy compatible in IdempotentCloseOutputStream

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/util/IdempotentCloseOutputStream.java
+++ b/api/src/main/java/org/commonjava/maven/galley/util/IdempotentCloseOutputStream.java
@@ -28,7 +28,7 @@ public class IdempotentCloseOutputStream
 {
     private AtomicBoolean closed = new AtomicBoolean( false );
 
-    final private OutputStream out;
+    final protected OutputStream out;
 
     protected IdempotentCloseOutputStream( final OutputStream out )
     {
@@ -62,4 +62,5 @@ public class IdempotentCloseOutputStream
             throws IOException {
         out.write( b );
     }
+
 }


### PR DESCRIPTION
Seems a compilation error of TimingOutputStream in indy, so I did the change.