### PR TITLE
Galley transfers inject fields keyed to upstream hostname

### DIFF
--- a/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
+++ b/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
@@ -30,6 +30,8 @@ import org.commonjava.maven.galley.spi.transport.TransportManager;
 import org.commonjava.maven.galley.transport.NoOpLocationExpander;
 import org.commonjava.maven.galley.transport.SimpleUrlLocationResolver;
 import org.commonjava.maven.galley.transport.htcli.conf.GlobalHttpConfiguration;
+import org.commonjava.o11yphant.honeycomb.config.HoneycombConfiguration;
+import org.commonjava.o11yphant.metrics.TrafficClassifier;
 import org.commonjava.o11yphant.metrics.conf.DefaultMetricsConfig;
 import org.commonjava.o11yphant.metrics.conf.MetricsConfig;
 import org.commonjava.o11yphant.metrics.system.StoragePathProvider;
@@ -44,6 +46,10 @@ import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 
 /**
@@ -190,5 +196,87 @@ public class TestCDIProvider
     public StoragePathProvider getStoragePathProvider()
     {
         return () -> null;
+    }
+
+    @Produces
+    @Default
+    public HoneycombConfiguration getHoneycombConfiguration()
+    {
+        return new HoneycombConfiguration()
+        {
+            @Override
+            public Map<String, Integer> getSpanRates()
+            {
+                return null;
+            }
+
+            @Override
+            public boolean isEnabled()
+            {
+                return false;
+            }
+
+            @Override
+            public String getServiceName()
+            {
+                return null;
+            }
+
+            @Override
+            public String getWriteKey()
+            {
+                return null;
+            }
+
+            @Override
+            public String getDataset()
+            {
+                return null;
+            }
+
+            @Override
+            public Integer getBaseSampleRate()
+            {
+                return null;
+            }
+
+            @Override
+            public Set<String> getFieldSet()
+            {
+                return null;
+            }
+
+            @Override
+            public String getEnvironmentMappings()
+            {
+                return null;
+            }
+
+            @Override
+            public String getCPNames()
+            {
+                return null;
+            }
+
+            @Override
+            public String getNodeId()
+            {
+                return null;
+            }
+        };
+    }
+
+    @Produces
+    @Default
+    public TrafficClassifier getTrafficClassifier()
+    {
+        return new TrafficClassifier()
+        {
+            @Override
+            protected List<String> calculateCachedFunctionClassifiers( String restPath, String method )
+            {
+                return Collections.emptyList();
+            }
+        };
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,11 @@
         <artifactId>o11yphant-metrics-core</artifactId>
         <version>${o11yphantVersion}</version>
       </dependency>
+      <dependency>
+        <groupId>org.commonjava.util</groupId>
+        <artifactId>o11yphant-honeycomb</artifactId>
+        <version>${o11yphantVersion}</version>
+      </dependency>
 
       <!-- JPA support -->
       <dependency>

--- a/transports/httpclient/pom.xml
+++ b/transports/httpclient/pom.xml
@@ -90,6 +90,10 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.util</groupId>
+      <artifactId>o11yphant-honeycomb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.util</groupId>
       <artifactId>o11yphant-metrics-api</artifactId>
     </dependency>
     <dependency>

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/HttpClientTransport.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/HttpClientTransport.java
@@ -47,6 +47,7 @@ import org.commonjava.maven.galley.transport.htcli.internal.HttpListing;
 import org.commonjava.maven.galley.transport.htcli.internal.HttpPublish;
 import org.commonjava.maven.galley.transport.htcli.internal.model.WrapperHttpLocation;
 import org.commonjava.maven.galley.transport.htcli.model.HttpLocation;
+import org.commonjava.o11yphant.honeycomb.HoneycombManager;
 import org.commonjava.o11yphant.metrics.api.MetricRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,6 +75,9 @@ public class HttpClientTransport
 
     @Inject
     private TransportMetricConfig metricConfig;
+
+    @Inject
+    private HoneycombManager honeycombManager;
 
     protected HttpClientTransport()
     {
@@ -114,7 +118,7 @@ public class HttpClientTransport
         throws TransferException
     {
         return new HttpDownload( getUrl( resource ), getHttpLocation( resource.getLocation() ), target, transferSizes, eventMetadata,
-                                 http, mapper, metricRegistry, metricConfig );
+                                 http, mapper, metricRegistry, metricConfig, honeycombManager );
     }
 
     @Override

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
@@ -66,6 +66,13 @@ public final class HttpDownload
 
     public HttpDownload( final String url, final HttpLocation location, final Transfer target,
                          final Map<Transfer, Long> transferSizes, final EventMetadata eventMetadata, final Http http,
+                         final ObjectMapper mapper )
+    {
+        this( url, location, target, transferSizes, eventMetadata, http, mapper, true, null, null, null );
+    }
+
+    public HttpDownload( final String url, final HttpLocation location, final Transfer target,
+                         final Map<Transfer, Long> transferSizes, final EventMetadata eventMetadata, final Http http,
                          final ObjectMapper mapper, final MetricRegistry metricRegistry,
                          final TransportMetricConfig transportMetricConfig,
                          final HoneycombManager honeycombManager )

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
@@ -16,7 +16,6 @@
 package org.commonjava.maven.galley.transport.htcli.internal;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.ClassUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
@@ -31,6 +30,7 @@ import org.commonjava.maven.galley.transport.htcli.Http;
 import org.commonjava.maven.galley.config.TransportMetricConfig;
 import org.commonjava.maven.galley.transport.htcli.model.HttpLocation;
 import org.commonjava.maven.galley.transport.htcli.util.HttpUtil;
+import org.commonjava.o11yphant.honeycomb.HoneycombManager;
 import org.commonjava.o11yphant.metrics.api.MetricRegistry;
 import org.commonjava.o11yphant.metrics.api.Timer;
 
@@ -60,21 +60,25 @@ public final class HttpDownload
 
     private final MetricRegistry metricRegistry;
 
-    private final TransportMetricConfig metricConfig;
+    private final HoneycombManager honeycombManager;
 
+    private final TransportMetricConfig transportMetricConfig;
 
     public HttpDownload( final String url, final HttpLocation location, final Transfer target,
                          final Map<Transfer, Long> transferSizes, final EventMetadata eventMetadata, final Http http,
                          final ObjectMapper mapper, final MetricRegistry metricRegistry,
-                         final TransportMetricConfig metricConfig )
+                         final TransportMetricConfig transportMetricConfig,
+                         final HoneycombManager honeycombManager )
     {
-        this( url, location, target, transferSizes, eventMetadata, http, mapper, true, metricRegistry, metricConfig );
+        this( url, location, target, transferSizes, eventMetadata, http, mapper, true, metricRegistry,
+              transportMetricConfig, honeycombManager );
     }
 
     public HttpDownload( final String url, final HttpLocation location, final Transfer target,
                          final Map<Transfer, Long> transferSizes, final EventMetadata eventMetadata, final Http http,
                          final ObjectMapper mapper, final boolean deleteFilesOnPath,
-                         final MetricRegistry metricRegistry, final TransportMetricConfig metricConfig )
+                         final MetricRegistry metricRegistry, final TransportMetricConfig transportMetricConfig,
+                         final HoneycombManager honeycombManager )
     {
         super( url, location, http );
         this.target = target;
@@ -83,30 +87,31 @@ public final class HttpDownload
         this.mapper = mapper;
         this.deleteFilesOnPath = deleteFilesOnPath;
         this.metricRegistry = metricRegistry;
-        this.metricConfig = metricConfig;
+        this.transportMetricConfig = transportMetricConfig;
+        this.honeycombManager = honeycombManager;
     }
 
     @Override
     public DownloadJob call()
     {
-        if ( metricConfig == null || !metricConfig.isEnabled() || metricRegistry == null )
+        if ( transportMetricConfig == null || !transportMetricConfig.isEnabled() || metricRegistry == null )
         {
             return doCall();
         }
 
         logger.trace( "Download metric enabled, location: {}", location );
 
-        String cls = ClassUtils.getAbbreviatedName( getClass().getName(), 1 ); // e.g., foo.bar.ClassA -> f.b.ClassA
+        String cls = getClass().getSimpleName();
 
         Timer repoTimer = null;
-        String metricName = metricConfig.getMetricUniqueName( location );
+        String metricName = transportMetricConfig.getMetricUniqueName( location );
         if ( metricName != null )
         {
-            repoTimer = metricRegistry.timer( name( metricConfig.getNodePrefix(), cls, "call", metricName ) );
+            repoTimer = metricRegistry.timer( name( transportMetricConfig.getNodePrefix(), cls, "call", metricName ) );
             logger.trace( "Measure repo metric, metricName: {}", metricName );
         }
 
-        final Timer globalTimer = metricRegistry.timer( name( metricConfig.getNodePrefix(), cls, "call" ) );
+        final Timer globalTimer = metricRegistry.timer( name( transportMetricConfig.getNodePrefix(), cls, "call" ) );
         final Timer.Context globalTimerContext = globalTimer.time();
         Timer.Context repoTimerContext = null;
         if ( repoTimer != null )
@@ -116,7 +121,17 @@ public final class HttpDownload
 
         try
         {
-            return doCall();
+            if ( honeycombManager != null )
+            {
+                return honeycombManager.withStandardMetricWrapper( () -> doCall(),
+                                                                   () -> name( transportMetricConfig.getNodePrefix(),
+                                                                               mangledName() ),
+                                                                   () -> appendix() );
+            }
+            else
+            {
+                return doCall();
+            }
         }
         finally
         {
@@ -126,6 +141,18 @@ public final class HttpDownload
                 repoTimerContext.stop();
             }
         }
+    }
+
+    // Generate a mangled name for metric/honeycomb. e.g., https://maven.apache.org to https.maven_apache_org
+    private String mangledName()
+    {
+        return name( this.request.getProtocolVersion().getProtocol(),
+                     this.request.getURI().getHost().replaceAll( "\\.", "_" ) );
+    }
+
+    private String appendix()
+    {
+        return response != null ? String.valueOf( response.getStatusLine().getStatusCode() ) : null;
     }
 
     private DownloadJob doCall()

--- a/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownloadTest.java
+++ b/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownloadTest.java
@@ -134,7 +134,7 @@ public class HttpDownloadTest
 
         HttpDownload dl =
                 new HttpDownload( url, location, transfer, new HashMap<Transfer, Long>(), new EventMetadata(),
-                                  fixture.getHttp(), new ObjectMapper(), metricRegistry, metricConfig );
+                                  fixture.getHttp(), new ObjectMapper(), metricRegistry, metricConfig, null );
 
         DownloadJob resultJob = dl.call();
 
@@ -153,7 +153,7 @@ public class HttpDownloadTest
         // second call should hit upstream again and succeed.
 
         dl = new HttpDownload( url, location, transfer, new HashMap<Transfer, Long>(), new EventMetadata(),
-                               fixture.getHttp(), new ObjectMapper(), metricRegistry, metricConfig );
+                               fixture.getHttp(), new ObjectMapper(), metricRegistry, metricConfig, null );
 
         resultJob = dl.call();
 
@@ -217,7 +217,7 @@ public class HttpDownloadTest
 
         HttpDownload dl =
                 new HttpDownload( url, location, transfer, new HashMap<Transfer, Long>(), new EventMetadata(),
-                                  fixture.getHttp(), new ObjectMapper(), metricRegistry, metricConfig );
+                                  fixture.getHttp(), new ObjectMapper(), metricRegistry, metricConfig, null );
 
         DownloadJob resultJob = dl.call();
 
@@ -236,7 +236,7 @@ public class HttpDownloadTest
         // second call should hit upstream again and succeed.
 
         dl = new HttpDownload( url, location, transfer, new HashMap<Transfer, Long>(), new EventMetadata(),
-                               fixture.getHttp(), new ObjectMapper(), metricRegistry, metricConfig );
+                               fixture.getHttp(), new ObjectMapper(), metricRegistry, metricConfig, null );
 
         resultJob = dl.call();
 
@@ -276,7 +276,7 @@ public class HttpDownloadTest
 
         final HttpDownload dl =
             new HttpDownload( url, location, transfer, transferSizes, new EventMetadata(), fixture.getHttp(), new ObjectMapper(),
-                              metricRegistry, metricConfig );
+                              metricRegistry, metricConfig, null );
         final DownloadJob resultJob = dl.call();
 
         final TransferException error = dl.getError();
@@ -326,7 +326,7 @@ public class HttpDownloadTest
 
         final HttpDownload dl =
                 new HttpDownload( url, location, transfer, transferSizes, new EventMetadata(), fixture.getHttp(), new ObjectMapper(),
-                                  metricRegistry, metricConfig );
+                                  metricRegistry, metricConfig, null );
         final DownloadJob resultJob = dl.call();
 
         final TransferException error = dl.getError();
@@ -362,7 +362,7 @@ public class HttpDownloadTest
 
         final HttpDownload dl =
             new HttpDownload( url, location, transfer, transferSizes, new EventMetadata(), fixture.getHttp(), new ObjectMapper(),
-                              metricRegistry, metricConfig );
+                              metricRegistry, metricConfig, null );
         final DownloadJob resultJob = dl.call();
 
         final TransferException error = dl.getError();
@@ -404,7 +404,7 @@ public class HttpDownloadTest
 
         final HttpDownload dl =
             new HttpDownload( url, location, transfer, transferSizes, new EventMetadata(), fixture.getHttp(), new ObjectMapper(),
-                              metricRegistry, metricConfig );
+                              metricRegistry, metricConfig, null );
         final DownloadJob resultJob = dl.call();
 
         final TransferException err = dl.getError();

--- a/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownloadTest.java
+++ b/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownloadTest.java
@@ -15,7 +15,6 @@
  */
 package org.commonjava.maven.galley.transport.htcli.internal;
 
-import static org.commonjava.o11yphant.metrics.util.MetricUtils.newDefaultMetricRegistry;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -24,14 +23,11 @@ import static org.junit.Assert.assertThat;
 import org.commonjava.maven.galley.TransferException;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.ConcreteResource;
-import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.spi.transport.DownloadJob;
-import org.commonjava.maven.galley.config.TransportMetricConfig;
 import org.commonjava.maven.galley.transport.htcli.model.HttpExchangeMetadata;
 import org.commonjava.maven.galley.transport.htcli.model.SimpleHttpLocation;
 import org.commonjava.maven.galley.transport.htcli.testutil.HttpTestFixture;
-import org.commonjava.o11yphant.metrics.DefaultMetricRegistry;
 import org.commonjava.test.http.expect.ExpectationHandler;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
@@ -54,33 +50,6 @@ import java.util.Map;
 @BMUnitConfig( debug = true )
 public class HttpDownloadTest
 {
-    private static DefaultMetricRegistry metricRegistry = newDefaultMetricRegistry();
-
-    private static TransportMetricConfig metricConfig = new TransportMetricConfig()
-    {
-        @Override
-        public boolean isEnabled()
-        {
-            return true;
-        }
-
-        @Override
-        public String getNodePrefix()
-        {
-            return null;
-        }
-
-        @Override
-        public String getMetricUniqueName( Location location )
-        {
-            if ( location.getName().equals( "test" ) )
-            {
-                return location.getName();
-            }
-            return null;
-        }
-    };
-
     @Rule
     public HttpTestFixture fixture = new HttpTestFixture( "download-basic" );
 
@@ -134,7 +103,7 @@ public class HttpDownloadTest
 
         HttpDownload dl =
                 new HttpDownload( url, location, transfer, new HashMap<Transfer, Long>(), new EventMetadata(),
-                                  fixture.getHttp(), new ObjectMapper(), metricRegistry, metricConfig, null );
+                                  fixture.getHttp(), new ObjectMapper() );
 
         DownloadJob resultJob = dl.call();
 
@@ -153,7 +122,7 @@ public class HttpDownloadTest
         // second call should hit upstream again and succeed.
 
         dl = new HttpDownload( url, location, transfer, new HashMap<Transfer, Long>(), new EventMetadata(),
-                               fixture.getHttp(), new ObjectMapper(), metricRegistry, metricConfig, null );
+                               fixture.getHttp(), new ObjectMapper() );
 
         resultJob = dl.call();
 
@@ -217,7 +186,7 @@ public class HttpDownloadTest
 
         HttpDownload dl =
                 new HttpDownload( url, location, transfer, new HashMap<Transfer, Long>(), new EventMetadata(),
-                                  fixture.getHttp(), new ObjectMapper(), metricRegistry, metricConfig, null );
+                                  fixture.getHttp(), new ObjectMapper() );
 
         DownloadJob resultJob = dl.call();
 
@@ -236,7 +205,7 @@ public class HttpDownloadTest
         // second call should hit upstream again and succeed.
 
         dl = new HttpDownload( url, location, transfer, new HashMap<Transfer, Long>(), new EventMetadata(),
-                               fixture.getHttp(), new ObjectMapper(), metricRegistry, metricConfig, null );
+                               fixture.getHttp(), new ObjectMapper() );
 
         resultJob = dl.call();
 
@@ -275,8 +244,7 @@ public class HttpDownloadTest
         assertThat( transfer.exists(), equalTo( false ) );
 
         final HttpDownload dl =
-            new HttpDownload( url, location, transfer, transferSizes, new EventMetadata(), fixture.getHttp(), new ObjectMapper(),
-                              metricRegistry, metricConfig, null );
+            new HttpDownload( url, location, transfer, transferSizes, new EventMetadata(), fixture.getHttp(), new ObjectMapper() );
         final DownloadJob resultJob = dl.call();
 
         final TransferException error = dl.getError();
@@ -325,8 +293,7 @@ public class HttpDownloadTest
         assertThat( transfer.exists(), equalTo( false ) );
 
         final HttpDownload dl =
-                new HttpDownload( url, location, transfer, transferSizes, new EventMetadata(), fixture.getHttp(), new ObjectMapper(),
-                                  metricRegistry, metricConfig, null );
+                new HttpDownload( url, location, transfer, transferSizes, new EventMetadata(), fixture.getHttp(), new ObjectMapper() );
         final DownloadJob resultJob = dl.call();
 
         final TransferException error = dl.getError();
@@ -361,8 +328,7 @@ public class HttpDownloadTest
         assertThat( transfer.exists(), equalTo( false ) );
 
         final HttpDownload dl =
-            new HttpDownload( url, location, transfer, transferSizes, new EventMetadata(), fixture.getHttp(), new ObjectMapper(),
-                              metricRegistry, metricConfig, null );
+            new HttpDownload( url, location, transfer, transferSizes, new EventMetadata(), fixture.getHttp(), new ObjectMapper() );
         final DownloadJob resultJob = dl.call();
 
         final TransferException error = dl.getError();
@@ -403,8 +369,7 @@ public class HttpDownloadTest
         assertThat( transfer.exists(), equalTo( false ) );
 
         final HttpDownload dl =
-            new HttpDownload( url, location, transfer, transferSizes, new EventMetadata(), fixture.getHttp(), new ObjectMapper(),
-                              metricRegistry, metricConfig, null );
+            new HttpDownload( url, location, transfer, transferSizes, new EventMetadata(), fixture.getHttp(), new ObjectMapper() );
         final DownloadJob resultJob = dl.call();
 
         final TransferException err = dl.getError();
@@ -427,7 +392,6 @@ public class HttpDownloadTest
     @Test
     public void simpleRetrieveOfAvailableUrl_MetricTest() throws Exception
     {
-        metricRegistry.startConsoleReporter( 1 );
         simpleRetrieveOfAvailableUrl();
         waitSeconds( 3 ); // wait for a while to see the metric
     }


### PR DESCRIPTION
This is to wrap the download job's doCall with withStandardMetricWrapper. So that the inteceptor can catch the elapse time and send to Honeycomb.