### PR TITLE
Move request construct early to avoid npe

### DIFF
--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
@@ -88,6 +88,7 @@ public final class HttpDownload
                          final HoneycombManager honeycombManager )
     {
         super( url, location, http );
+        this.request = new HttpGet( url );
         this.target = target;
         this.transferSizes = transferSizes;
         this.eventMetadata = eventMetadata;
@@ -164,7 +165,6 @@ public final class HttpDownload
 
     private DownloadJob doCall()
     {
-        request = new HttpGet( url );
         String oldName = Thread.currentThread().getName();
         try
         {


### PR DESCRIPTION
The request object is used to create honeycomb name. Construct it early. 