### PR TITLE
Add dependencies for JDK11 to compile code.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -45,5 +45,13 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-interpolation</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>javax.activation-api</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,8 @@
     <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
     <hibernateVersion>5.4.4.Final</hibernateVersion>
     <h2Version>1.4.188</h2Version>
+    <activationVersion>1.2.0</activationVersion>
+    <annotationVersion>1.3.2</annotationVersion>
     <test-forkCount>1</test-forkCount>
     <test-redirectOutput>true</test-redirectOutput>
 
@@ -343,7 +345,16 @@
         <artifactId>cassandra-unit</artifactId>
         <version>${cassandraUnitVersion}</version>
       </dependency>
-
+      <dependency>
+        <groupId>javax.activation</groupId>
+        <artifactId>javax.activation-api</artifactId>
+        <version>${activationVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${annotationVersion}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -428,6 +439,7 @@
             <redirectTestOutputToFile>${test-redirectOutput}</redirectTestOutputToFile>
             <forkCount>${test-forkCount}</forkCount>
             <reuseForks>false</reuseForks>
+            <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
 These are 2 dependencies that are bundled in JDK8. No longer found in JDK11.