### PR TITLE
Bump junit to 4.13.1 for security fix

### DIFF
--- a/api/src/test/java/org/commonjava/maven/galley/io/SpecialPathConstantsTest.java
+++ b/api/src/test/java/org/commonjava/maven/galley/io/SpecialPathConstantsTest.java
@@ -19,7 +19,7 @@ import org.commonjava.maven.galley.model.SimpleLocation;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Created by jdcasey on 5/18/16.

--- a/api/src/test/java/org/commonjava/maven/galley/util/PathUtilsTest.java
+++ b/api/src/test/java/org/commonjava/maven/galley/util/PathUtilsTest.java
@@ -16,7 +16,7 @@
 package org.commonjava.maven.galley.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/caches/partyline/src/test/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProviderConcurrentIOTest.java
+++ b/caches/partyline/src/test/java/org/commonjava/maven/galley/cache/partyline/PartyLineCacheProviderConcurrentIOTest.java
@@ -46,7 +46,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 @RunWith( org.jboss.byteman.contrib.bmunit.BMUnitRunner.class )

--- a/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderCassandraTest.java
+++ b/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderCassandraTest.java
@@ -61,7 +61,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PathMappedCacheProviderCassandraTest
                 extends CacheProviderTCK

--- a/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderJPATest.java
+++ b/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderJPATest.java
@@ -45,7 +45,7 @@ import java.util.concurrent.Executors;
 
 import static org.commonjava.maven.galley.cache.testutil.AssertUtil.assertThrows;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class PathMappedCacheProviderJPATest

--- a/caches/tck/pom.xml
+++ b/caches/tck/pom.xml
@@ -39,6 +39,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.commonjava.atlas</groupId>
       <artifactId>atlas-identities</artifactId>
       <exclusions>

--- a/caches/tck/src/main/java/org/commonjava/maven/galley/cache/CacheProviderTCK.java
+++ b/caches/tck/src/main/java/org/commonjava/maven/galley/cache/CacheProviderTCK.java
@@ -35,8 +35,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.apache.commons.lang.StringUtils.join;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public abstract class CacheProviderTCK
 {
@@ -57,7 +57,7 @@ public abstract class CacheProviderTCK
         cache.lockWrite( res );
         cache.waitForWriteUnlock( res );
 
-        assertThat( cache.isWriteLocked( res ), equalTo( false ) );
+        assertThat( cache.isWriteLocked( res ), is( false ) );
     }
 
     @Test
@@ -101,7 +101,7 @@ public abstract class CacheProviderTCK
         out.write( content.getBytes( "UTF-8" ) );
         out.close();
 
-        assertThat( provider.isDirectory( new ConcreteResource( loc, dir ) ), equalTo( true ) );
+        assertThat( provider.isDirectory( new ConcreteResource( loc, dir ) ), is( true ) );
     }
 
     @Test
@@ -130,8 +130,8 @@ public abstract class CacheProviderTCK
 
         System.out.printf( "\n\nFile listing is:\n\n  %s\n\n\n", join( listing, "\n  " ) );
 
-        assertThat( listing.size() > 0, equalTo( true ) );
-        assertThat( listing.contains( "file.txt" ), equalTo( true ) );
+        assertThat( listing.size() > 0, is( true ) );
+        assertThat( listing.contains( "file.txt" ), is( true ) );
     }
 
     @Test
@@ -148,7 +148,7 @@ public abstract class CacheProviderTCK
         out.write( content.getBytes( "UTF-8" ) );
         out.close();
 
-        assertThat( provider.exists( new ConcreteResource( loc, fname ) ), equalTo( true ) );
+        assertThat( provider.exists( new ConcreteResource( loc, fname ) ), is( true ) );
     }
 
     @Test
@@ -165,11 +165,11 @@ public abstract class CacheProviderTCK
         out.write( content.getBytes( "UTF-8" ) );
         out.close();
 
-        assertThat( provider.exists( new ConcreteResource( loc, fname ) ), equalTo( true ) );
+        assertThat( provider.exists( new ConcreteResource( loc, fname ) ), is( true ) );
 
         provider.delete( new ConcreteResource( loc, fname ) );
 
-        assertThat( provider.exists( new ConcreteResource( loc, fname ) ), equalTo( false ) );
+        assertThat( provider.exists( new ConcreteResource( loc, fname ) ), is( false ) );
     }
 
     @Test
@@ -197,7 +197,7 @@ public abstract class CacheProviderTCK
 
         final String result = new String( baos.toByteArray(), "UTF-8" );
 
-        assertThat( result, equalTo( content ) );
+        assertThat( result, is( content ) );
     }
 
     @Test
@@ -229,7 +229,7 @@ public abstract class CacheProviderTCK
 
         final String result = new String( baos.toByteArray(), "UTF-8" );
 
-        assertThat( result, equalTo( content ) );
+        assertThat( result, is( content ) );
     }
 
 }

--- a/caches/tck/src/main/java/org/commonjava/maven/galley/cache/testutil/TestIOUtils.java
+++ b/caches/tck/src/main/java/org/commonjava/maven/galley/cache/testutil/TestIOUtils.java
@@ -15,7 +15,10 @@
  */
 package org.commonjava.maven.galley.cache.testutil;
 
+import org.junit.rules.TemporaryFolder;
+
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.CountDownLatch;
@@ -57,6 +60,19 @@ public final class TestIOUtils
             System.out.println( "Threads await Exception." );
             return false;
         }
+    }
+
+    public static File newTempFolder( final TemporaryFolder temp, final String... folderName )
+    {
+        try
+        {
+            return temp.newFolder( folderName );
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+
     }
 
 }

--- a/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/EmbeddableCDI_HTTPArtifactDownload_Test.java
+++ b/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/EmbeddableCDI_HTTPArtifactDownload_Test.java
@@ -35,7 +35,7 @@ import java.io.InputStream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Created by jdcasey on 9/14/15.

--- a/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/EmbeddableCDI_HTTPArtifactMetadataDownload_Test.java
+++ b/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/EmbeddableCDI_HTTPArtifactMetadataDownload_Test.java
@@ -34,7 +34,7 @@ import java.io.InputStream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Created by jdcasey on 9/14/15.

--- a/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/EmbeddableCDI_HTTPDownload_Test.java
+++ b/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/EmbeddableCDI_HTTPDownload_Test.java
@@ -33,7 +33,7 @@ import java.io.InputStream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Created by jdcasey on 9/14/15.

--- a/core/src/test/java/org/commonjava/maven/galley/AbstractTransferManagerTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/AbstractTransferManagerTest.java
@@ -36,7 +36,7 @@ import java.util.Collections;
 import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public abstract class AbstractTransferManagerTest
 {

--- a/core/src/test/java/org/commonjava/maven/galley/TransferManagerImplTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/TransferManagerImplTest.java
@@ -17,6 +17,7 @@ package org.commonjava.maven.galley;
 
 import org.commonjava.maven.galley.cache.FileCacheProvider;
 import org.commonjava.maven.galley.cache.MockPathGenerator;
+import org.commonjava.maven.galley.cache.testutil.TestIOUtils;
 import org.commonjava.maven.galley.config.TransportManagerConfig;
 import org.commonjava.maven.galley.event.NoOpFileEventManager;
 import org.commonjava.maven.galley.internal.TransferManagerImpl;
@@ -75,7 +76,7 @@ public class TransferManagerImplTest
         transport = new TestTransport();
         transportMgr = new TransportManagerImpl( transport );
         cacheProvider =
-            new FileCacheProvider( temp.newFolder( "cache" ), new MockPathGenerator(), new NoOpFileEventManager(),
+            new FileCacheProvider( TestIOUtils.newTempFolder( temp, "cache" ), new MockPathGenerator(), new NoOpFileEventManager(),
                                    new TransferDecoratorManager( new NoOpTransferDecorator() ), true );
         nfc = new MemoryNotFoundCache();
         fileEvents = new NoOpFileEventManager();

--- a/core/src/test/java/org/commonjava/maven/galley/cache/FileCacheProviderTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/cache/FileCacheProviderTest.java
@@ -30,7 +30,7 @@ import java.io.File;
 import java.io.OutputStream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class FileCacheProviderTest

--- a/core/src/test/java/org/commonjava/maven/galley/cache/TryToReadWhileWritingTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/cache/TryToReadWhileWritingTest.java
@@ -20,7 +20,7 @@ import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @BMUnitConfig( loadDirectory = "target/test-classes/bmunit", debug = true )
 @BMScript( "TryToReadWhileWritingTestCase.btm" )

--- a/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingInputStreamTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingInputStreamTest.java
@@ -31,9 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -42,7 +40,7 @@ import java.util.Map;
 import static org.commonjava.maven.galley.io.checksum.ContentDigest.MD5;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ChecksummingInputStreamTest
 {

--- a/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStreamTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingOutputStreamTest.java
@@ -39,7 +39,7 @@ import java.util.Map;
 import static org.commonjava.maven.galley.io.checksum.ContentDigest.MD5;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ChecksummingOutputStreamTest
 {

--- a/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingTransferDecoratorTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/io/checksum/ChecksummingTransferDecoratorTest.java
@@ -53,7 +53,7 @@ import static org.commonjava.maven.galley.io.checksum.testutil.TestDecoratorAdvi
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Created by jdcasey on 4/27/17.

--- a/core/src/test/java/org/commonjava/maven/galley/io/checksum/Md5GeneratorFactoryTest.java
+++ b/core/src/test/java/org/commonjava/maven/galley/io/checksum/Md5GeneratorFactoryTest.java
@@ -34,7 +34,7 @@ import java.security.MessageDigest;
 import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Md5GeneratorFactoryTest
 {

--- a/maven/src/test/java/org/commonjava/maven/galley/maven/internal/version/ArtifactManagerImplTest.java
+++ b/maven/src/test/java/org/commonjava/maven/galley/maven/internal/version/ArtifactManagerImplTest.java
@@ -32,7 +32,7 @@ import org.w3c.dom.Document;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class ArtifactManagerImplTest

--- a/maven/src/test/java/org/commonjava/maven/galley/maven/internal/version/VersionResolverImplTest.java
+++ b/maven/src/test/java/org/commonjava/maven/galley/maven/internal/version/VersionResolverImplTest.java
@@ -17,7 +17,7 @@ package org.commonjava.maven.galley.maven.internal.version;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/maven/src/test/java/org/commonjava/maven/galley/maven/model/view/DependencyViewTest.java
+++ b/maven/src/test/java/org/commonjava/maven/galley/maven/model/view/DependencyViewTest.java
@@ -16,7 +16,7 @@
 package org.commonjava.maven.galley.maven.model.view;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.HashSet;
 import java.util.List;

--- a/maven/src/test/java/org/commonjava/maven/galley/maven/model/view/MavenPomViewTest.java
+++ b/maven/src/test/java/org/commonjava/maven/galley/maven/model/view/MavenPomViewTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class MavenPomViewTest

--- a/maven/src/test/java/org/commonjava/maven/galley/maven/parse/XMLInfrastructureTest.java
+++ b/maven/src/test/java/org/commonjava/maven/galley/maven/parse/XMLInfrastructureTest.java
@@ -16,7 +16,7 @@
 package org.commonjava.maven.galley.maven.parse;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.InputStream;
 

--- a/maven/src/test/java/org/commonjava/maven/galley/maven/rel/MavenModelProcessorTest.java
+++ b/maven/src/test/java/org/commonjava/maven/galley/maven/rel/MavenModelProcessorTest.java
@@ -48,7 +48,7 @@ import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class MavenModelProcessorTest

--- a/maven/src/test/java/org/commonjava/maven/galley/maven/util/ArtifactPathUtilsTest.java
+++ b/maven/src/test/java/org/commonjava/maven/galley/maven/util/ArtifactPathUtilsTest.java
@@ -16,7 +16,7 @@
 package org.commonjava.maven.galley.maven.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.commonjava.atlas.maven.ident.ref.ProjectVersionRef;
 import org.commonjava.atlas.maven.ident.ref.SimpleProjectVersionRef;

--- a/maven/src/test/java/org/commonjava/maven/galley/maven/util/PomPeekTest.java
+++ b/maven/src/test/java/org/commonjava/maven/galley/maven/util/PomPeekTest.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class PomPeekTest

--- a/pom.xml
+++ b/pom.xml
@@ -207,8 +207,12 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.10</version>
-        <scope>test</scope>
+        <version>4.13.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>1.3</version>
       </dependency>
 
       <!-- Used to do bmunit -->
@@ -366,6 +370,12 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.commonjava.atlas</groupId>

--- a/testing/api/pom.xml
+++ b/testing/api/pom.xml
@@ -48,6 +48,7 @@
     <dependency>
       <groupId>org.commonjava.maven.galley</groupId>
       <artifactId>galley-cache-tck</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>

--- a/testing/api/src/main/java/org/commonjava/maven/galley/testing/core/ApiFixture.java
+++ b/testing/api/src/main/java/org/commonjava/maven/galley/testing/core/ApiFixture.java
@@ -27,6 +27,7 @@ import org.commonjava.maven.galley.testing.core.event.TestFileEventManager;
 import org.commonjava.maven.galley.testing.core.io.TestTransferDecorator;
 import org.commonjava.maven.galley.testing.core.transport.TestLocationExpander;
 import org.commonjava.maven.galley.testing.core.transport.TestTransport;
+import org.commonjava.maven.galley.cache.testutil.TestIOUtils;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
 
@@ -81,7 +82,7 @@ public class ApiFixture
 
         if ( cache == null )
         {
-            cache = new TestCacheProvider( temp.newFolder( "cache" ), events, decorator );
+            cache = new TestCacheProvider( TestIOUtils.newTempFolder( temp, "cache" ), events, decorator );
         }
 
         if ( transport == null )

--- a/transports/filearc/src/test/java/org/commonjava/maven/galley/filearc/internal/util/ZipUtilsTest.java
+++ b/transports/filearc/src/test/java/org/commonjava/maven/galley/filearc/internal/util/ZipUtilsTest.java
@@ -18,7 +18,7 @@ package org.commonjava.maven.galley.filearc.internal.util;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 

--- a/transports/httpclient/pom.xml
+++ b/transports/httpclient/pom.xml
@@ -101,6 +101,11 @@
       <artifactId>o11yphant-metrics-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.commonjava.maven.galley</groupId>
+      <artifactId>galley-cache-tck</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   
   <properties>

--- a/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownloadTest.java
+++ b/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownloadTest.java
@@ -19,7 +19,7 @@ import static org.commonjava.o11yphant.metrics.util.MetricUtils.newDefaultMetric
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.commonjava.maven.galley.TransferException;
 import org.commonjava.maven.galley.config.TransportMetricConfig;

--- a/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpExistenceTest.java
+++ b/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpExistenceTest.java
@@ -18,7 +18,7 @@ package org.commonjava.maven.galley.transport.htcli.internal;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.commonjava.maven.galley.TransferException;
 import org.commonjava.maven.galley.model.ConcreteResource;

--- a/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpListTest.java
+++ b/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpListTest.java
@@ -17,7 +17,7 @@ package org.commonjava.maven.galley.transport.htcli.internal;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.InputStream;

--- a/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpListingTest.java
+++ b/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/HttpListingTest.java
@@ -16,7 +16,7 @@
 package org.commonjava.maven.galley.transport.htcli.internal;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/UploadMetadataGenTransferDecoratorTest.java
+++ b/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/internal/UploadMetadataGenTransferDecoratorTest.java
@@ -16,6 +16,7 @@
 package org.commonjava.maven.galley.transport.htcli.internal;
 
 import org.apache.commons.io.FileUtils;
+import org.commonjava.maven.galley.cache.testutil.TestIOUtils;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.io.TransferDecoratorManager;
 import org.commonjava.maven.galley.model.ConcreteResource;
@@ -73,7 +74,7 @@ public class UploadMetadataGenTransferDecoratorTest
     @Before
     public void prepare()
     {
-        tempFolder = folder.newFolder( "cache" );
+        tempFolder = TestIOUtils.newTempFolder( folder, "cache" );
         final UploadMetadataGenTransferDecorator decorator =
                 new UploadMetadataGenTransferDecorator( specialPathManager, null );
         provider = new TestCacheProvider( tempFolder, events, new TransferDecoratorManager( decorator ) );

--- a/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/testutil/HttpTestFixture.java
+++ b/transports/httpclient/src/test/java/org/commonjava/maven/galley/transport/htcli/testutil/HttpTestFixture.java
@@ -16,6 +16,7 @@
 package org.commonjava.maven.galley.transport.htcli.testutil;
 
 import org.commonjava.maven.galley.auth.PasswordEntry;
+import org.commonjava.maven.galley.cache.testutil.TestIOUtils;
 import org.commonjava.maven.galley.io.TransferDecoratorManager;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Transfer;
@@ -84,7 +85,7 @@ public class HttpTestFixture
 
         this.decorator = decorator;
 
-        cache = new TestCacheProvider( folder.newFolder( "cache" ), events, new TransferDecoratorManager( decorator ) );
+        cache = new TestCacheProvider( newFolder( "cache" ), events, new TransferDecoratorManager( decorator ) );
 
         http = new HttpImpl( this );
     }
@@ -154,7 +155,7 @@ public class HttpTestFixture
 
     public File newFolder( final String... folderNames )
     {
-        return folder.newFolder( folderNames );
+        return TestIOUtils.newTempFolder( folder, folderNames );
     }
 
     public File newFolder()


### PR DESCRIPTION
Seems junit 4.13 has some api changes on hamcrest level like below:
       * CoreMatchers.equalTo -> CoreMatchers.is
       * TemporaryFolder.newFolder(folder...) will throw IOException
       * Deprecated org.junit.Assert.assertThat to use org.hamcrest.MatcherAssert.assertThat