### PR TITLE
Update o11 version to 1.4-SNAPSHOT

### DIFF
--- a/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
+++ b/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
@@ -274,7 +274,7 @@ public class TestCDIProvider
         return new TrafficClassifier()
         {
             @Override
-            protected List<String> calculateCachedFunctionClassifiers( String restPath, String method )
+            protected List<String> calculateCachedFunctionClassifiers( String restPath, String method, Map<String, String> headers )
             {
                 return Collections.emptyList();
             }

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <weldVersion>2.4.6.Final</weldVersion>
     <javaVersion>1.8</javaVersion>
     <byteman.version>4.0.13</byteman.version>
-    <o11yphantVersion>1.3-SNAPSHOT</o11yphantVersion>
+    <o11yphantVersion>1.4-SNAPSHOT</o11yphantVersion>
     <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
     <hibernateVersion>5.4.4.Final</hibernateVersion>
     <h2Version>1.4.188</h2Version>


### PR DESCRIPTION
Separated core/api from o11 1.3, and this resolves NoSuchMethodError during indy client metrics building