### PR TITLE
Adjust to refactored o11yphant trace API

### DIFF
--- a/cdi-embedder/pom.xml
+++ b/cdi-embedder/pom.xml
@@ -90,6 +90,16 @@
       <artifactId>o11yphant-metrics-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.commonjava.util</groupId>
+      <artifactId>o11yphant-trace-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.util</groupId>
+      <artifactId>o11yphant-trace-otel</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 </project>

--- a/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
+++ b/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
@@ -15,7 +15,6 @@
  */
 package org.commonjava.maven.galley.embed;
 
-import io.opentelemetry.api.trace.Tracer;
 import org.commonjava.cdi.util.weft.config.DefaultWeftConfig;
 import org.commonjava.cdi.util.weft.config.WeftConfig;
 import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProvider;
@@ -31,7 +30,7 @@ import org.commonjava.maven.galley.spi.transport.TransportManager;
 import org.commonjava.maven.galley.transport.NoOpLocationExpander;
 import org.commonjava.maven.galley.transport.SimpleUrlLocationResolver;
 import org.commonjava.maven.galley.transport.htcli.conf.GlobalHttpConfiguration;
-import org.commonjava.o11yphant.metrics.DefaultTrafficClassifier;
+import org.commonjava.o11yphant.metrics.AbstractTrafficClassifier;
 import org.commonjava.o11yphant.metrics.conf.DefaultMetricsConfig;
 import org.commonjava.o11yphant.metrics.conf.MetricsConfig;
 import org.commonjava.o11yphant.metrics.sli.GoldenSignalsMetricSet;
@@ -222,6 +221,12 @@ public class TestCDIProvider
             }
 
             @Override
+            public boolean isConsoleTransport()
+            {
+                return false;
+            }
+
+            @Override
             public String getServiceName()
             {
                 return "galley";
@@ -251,6 +256,12 @@ public class TestCDIProvider
 
             @Override
             public boolean isEnabled()
+            {
+                return false;
+            }
+
+            @Override
+            public boolean isConsoleTransport()
             {
                 return false;
             }
@@ -295,9 +306,9 @@ public class TestCDIProvider
 
     @Produces
     @Default
-    public DefaultTrafficClassifier getTrafficClassifier()
+    public AbstractTrafficClassifier getTrafficClassifier()
     {
-        return new DefaultTrafficClassifier()
+        return new AbstractTrafficClassifier()
         {
             @Override
             protected List<String> calculateCachedFunctionClassifiers( String restPath, String method, Map<String, String> headers )

--- a/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
+++ b/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
@@ -30,13 +30,16 @@ import org.commonjava.maven.galley.spi.transport.TransportManager;
 import org.commonjava.maven.galley.transport.NoOpLocationExpander;
 import org.commonjava.maven.galley.transport.SimpleUrlLocationResolver;
 import org.commonjava.maven.galley.transport.htcli.conf.GlobalHttpConfiguration;
-import org.commonjava.o11yphant.honeycomb.config.HoneycombConfiguration;
 import org.commonjava.o11yphant.metrics.DefaultTrafficClassifier;
-import org.commonjava.o11yphant.metrics.TrafficClassifier;
 import org.commonjava.o11yphant.metrics.conf.DefaultMetricsConfig;
 import org.commonjava.o11yphant.metrics.conf.MetricsConfig;
 import org.commonjava.o11yphant.metrics.sli.GoldenSignalsMetricSet;
 import org.commonjava.o11yphant.metrics.system.StoragePathProvider;
+import org.commonjava.o11yphant.otel.OtelConfiguration;
+import org.commonjava.o11yphant.otel.OtelTracePlugin;
+import org.commonjava.o11yphant.trace.RootSpanDecorator;
+import org.commonjava.o11yphant.trace.TraceManager;
+import org.commonjava.o11yphant.trace.TracerConfiguration;
 import org.commonjava.util.partyline.JoinableFileManager;
 import org.junit.Assert;
 import org.junit.rules.TemporaryFolder;
@@ -48,6 +51,7 @@ import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -202,9 +206,20 @@ public class TestCDIProvider
 
     @Produces
     @Default
-    public HoneycombConfiguration getHoneycombConfiguration()
+    public TraceManager getTraceManager()
     {
-        return new HoneycombConfiguration()
+        OtelConfiguration otelConf = new OtelConfiguration()
+        {
+        };
+
+        return new TraceManager( new OtelTracePlugin( otelConf ), new RootSpanDecorator( new ArrayList<>() ) );
+    }
+
+    @Produces
+    @Default
+    public TracerConfiguration getTracerConfiguration()
+    {
+        return new TracerConfiguration()
         {
             @Override
             public Map<String, Integer> getSpanRates()
@@ -220,18 +235,6 @@ public class TestCDIProvider
 
             @Override
             public String getServiceName()
-            {
-                return null;
-            }
-
-            @Override
-            public String getWriteKey()
-            {
-                return null;
-            }
-
-            @Override
-            public String getDataset()
             {
                 return null;
             }

--- a/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
+++ b/cdi-embedder/src/test/java/org/commonjava/maven/galley/embed/TestCDIProvider.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.maven.galley.embed;
 
+import io.opentelemetry.api.trace.Tracer;
 import org.commonjava.cdi.util.weft.config.DefaultWeftConfig;
 import org.commonjava.cdi.util.weft.config.WeftConfig;
 import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProvider;
@@ -37,7 +38,7 @@ import org.commonjava.o11yphant.metrics.sli.GoldenSignalsMetricSet;
 import org.commonjava.o11yphant.metrics.system.StoragePathProvider;
 import org.commonjava.o11yphant.otel.OtelConfiguration;
 import org.commonjava.o11yphant.otel.OtelTracePlugin;
-import org.commonjava.o11yphant.trace.RootSpanDecorator;
+import org.commonjava.o11yphant.trace.SpanFieldsDecorator;
 import org.commonjava.o11yphant.trace.TraceManager;
 import org.commonjava.o11yphant.trace.TracerConfiguration;
 import org.commonjava.util.partyline.JoinableFileManager;
@@ -212,7 +213,28 @@ public class TestCDIProvider
         {
         };
 
-        return new TraceManager( new OtelTracePlugin( otelConf ), new RootSpanDecorator( new ArrayList<>() ) );
+        TracerConfiguration traceConf = new TracerConfiguration()
+        {
+            @Override
+            public boolean isEnabled()
+            {
+                return false;
+            }
+
+            @Override
+            public String getServiceName()
+            {
+                return "galley";
+            }
+
+            @Override
+            public String getNodeId()
+            {
+                return "node";
+            }
+        };
+
+        return new TraceManager( new OtelTracePlugin( traceConf, otelConf ), new SpanFieldsDecorator( new ArrayList<>() ), getTracerConfiguration() );
     }
 
     @Produces

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <partylineVersion>1.16</partylineVersion>
     <pathmappedStorageVersion>1.4</pathmappedStorageVersion>
     <weftVersion>1.17</weftVersion>
-    <jhttpcVersion>1.9</jhttpcVersion>
+    <jhttpcVersion>1.12-SNAPSHOT</jhttpcVersion>
     <infinispanVersion>9.4.7.Final</infinispanVersion>
     <weldVersion>2.4.6.Final</weldVersion>
     <javaVersion>1.8</javaVersion>
@@ -330,6 +330,11 @@
       <dependency>
         <groupId>org.commonjava.util</groupId>
         <artifactId>o11yphant-trace-api</artifactId>
+        <version>${o11yphantVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.util</groupId>
+        <artifactId>o11yphant-trace-helper-jhttpc</artifactId>
         <version>${o11yphantVersion}</version>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,17 @@
       </dependency>
       <dependency>
         <groupId>org.commonjava.util</groupId>
-        <artifactId>o11yphant-honeycomb-core</artifactId>
+        <artifactId>o11yphant-trace-core</artifactId>
+        <version>${o11yphantVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.util</groupId>
+        <artifactId>o11yphant-trace-otel</artifactId>
+        <version>${o11yphantVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.util</groupId>
+        <artifactId>o11yphant-trace-api</artifactId>
         <version>${o11yphantVersion}</version>
       </dependency>
 

--- a/transports/httpclient/pom.xml
+++ b/transports/httpclient/pom.xml
@@ -98,6 +98,10 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.util</groupId>
+      <artifactId>o11yphant-trace-helper-jhttpc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.util</groupId>
       <artifactId>o11yphant-metrics-api</artifactId>
     </dependency>
     <dependency>

--- a/transports/httpclient/pom.xml
+++ b/transports/httpclient/pom.xml
@@ -90,7 +90,11 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.util</groupId>
-      <artifactId>o11yphant-honeycomb-core</artifactId>
+      <artifactId>o11yphant-trace-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.util</groupId>
+      <artifactId>o11yphant-trace-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.commonjava.util</groupId>

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/HttpClientTransport.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/HttpClientTransport.java
@@ -15,21 +15,10 @@
  */
 package org.commonjava.maven.galley.transport.htcli;
 
-import static org.commonjava.maven.galley.util.UrlUtils.buildUrl;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Map;
-
-import javax.annotation.PreDestroy;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.inject.Named;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.commonjava.maven.galley.TransferException;
 import org.commonjava.maven.galley.TransferLocationException;
+import org.commonjava.maven.galley.config.TransportMetricConfig;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Location;
@@ -39,7 +28,6 @@ import org.commonjava.maven.galley.spi.transport.ExistenceJob;
 import org.commonjava.maven.galley.spi.transport.ListingJob;
 import org.commonjava.maven.galley.spi.transport.PublishJob;
 import org.commonjava.maven.galley.spi.transport.Transport;
-import org.commonjava.maven.galley.config.TransportMetricConfig;
 import org.commonjava.maven.galley.transport.htcli.conf.GlobalHttpConfiguration;
 import org.commonjava.maven.galley.transport.htcli.internal.HttpDownload;
 import org.commonjava.maven.galley.transport.htcli.internal.HttpExistence;
@@ -47,12 +35,21 @@ import org.commonjava.maven.galley.transport.htcli.internal.HttpListing;
 import org.commonjava.maven.galley.transport.htcli.internal.HttpPublish;
 import org.commonjava.maven.galley.transport.htcli.internal.model.WrapperHttpLocation;
 import org.commonjava.maven.galley.transport.htcli.model.HttpLocation;
-import org.commonjava.o11yphant.honeycomb.HoneycombManager;
 import org.commonjava.o11yphant.metrics.api.MetricRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
+import static org.commonjava.maven.galley.util.UrlUtils.buildUrl;
 
 @ApplicationScoped
 @Named
@@ -75,9 +72,6 @@ public class HttpClientTransport
 
     @Inject
     private TransportMetricConfig metricConfig;
-
-    @Inject
-    private HoneycombManager honeycombManager;
 
     protected HttpClientTransport()
     {

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/HttpImpl.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/HttpImpl.java
@@ -32,7 +32,10 @@ import org.commonjava.maven.galley.transport.htcli.internal.util.LocationLookup;
 import org.commonjava.maven.galley.transport.htcli.model.HttpLocation;
 import org.commonjava.maven.galley.transport.htcli.util.HttpUtil;
 import org.commonjava.maven.galley.util.LocationUtils;
+import org.commonjava.o11yphant.jhttpc.SpanningHttpFactory;
+import org.commonjava.o11yphant.trace.TraceManager;
 import org.commonjava.util.jhttpc.HttpFactory;
+import org.commonjava.util.jhttpc.HttpFactoryIfc;
 import org.commonjava.util.jhttpc.JHttpCException;
 import org.commonjava.util.jhttpc.model.SiteConfig;
 import org.commonjava.util.jhttpc.model.SiteConfigBuilder;
@@ -41,6 +44,7 @@ import org.commonjava.util.jhttpc.model.SiteTrustType;
 import javax.enterprise.context.ApplicationScoped;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Optional;
 
 @ApplicationScoped
 public class HttpImpl
@@ -48,9 +52,17 @@ public class HttpImpl
 {
     private final PasswordManager passwords;
 
-    private final HttpFactory httpFactory;
+    private final HttpFactoryIfc httpFactory;
 
     private final LocationLookup locationLookup;
+
+    public HttpImpl( final PasswordManager passwords, Optional<TraceManager> traceManager )
+    {
+        this.passwords = passwords;
+        this.locationLookup = new LocationLookup();
+        this.httpFactory = new SpanningHttpFactory(
+                        new HttpFactory( new HttpFactoryPasswordDelegate( passwords, locationLookup ) ), traceManager );
+    }
 
     public HttpImpl( final PasswordManager passwords )
     {

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/AbstractHttpJob.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/AbstractHttpJob.java
@@ -110,7 +110,6 @@ public abstract class AbstractHttpJob
             final StatusLine line = response.getStatusLine();
             final int sc = line.getStatusCode();
 
-            addFieldToActiveSpan( "target-http-status", sc );
             logger.trace( "{} {} : {}", request.getMethod(), line, url );
 
             if ( sc > 399 && sc != 404 && sc != 408 && sc != 502 && sc != 503 && sc != 504 )

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
@@ -30,9 +30,9 @@ import org.commonjava.maven.galley.transport.htcli.Http;
 import org.commonjava.maven.galley.config.TransportMetricConfig;
 import org.commonjava.maven.galley.transport.htcli.model.HttpLocation;
 import org.commonjava.maven.galley.transport.htcli.util.HttpUtil;
-import org.commonjava.o11yphant.honeycomb.util.InterceptorUtils;
 import org.commonjava.o11yphant.metrics.api.MetricRegistry;
 import org.commonjava.o11yphant.metrics.api.Timer;
+import org.commonjava.o11yphant.trace.util.InterceptorUtils;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpDownload.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.apache.commons.io.IOUtils.copy;
 import static org.commonjava.o11yphant.metrics.util.NameUtils.name;
+import static org.commonjava.o11yphant.trace.TraceManager.addFieldToActiveSpan;
 
 public final class HttpDownload
     extends AbstractHttpJob
@@ -103,6 +104,9 @@ public final class HttpDownload
         }
 
         logger.trace( "Download metric enabled, location: {}", location );
+
+        addFieldToActiveSpan( "http-target", request.getURI().toASCIIString() );
+        addFieldToActiveSpan( "activity", "httpclient-download" );
 
         String cls = getClass().getSimpleName();
 

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpExistence.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpExistence.java
@@ -24,6 +24,8 @@ import org.commonjava.maven.galley.transport.htcli.model.HttpLocation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import static org.commonjava.o11yphant.trace.TraceManager.addFieldToActiveSpan;
+
 public final class HttpExistence
     extends AbstractHttpJob
     implements ExistenceJob
@@ -47,6 +49,9 @@ public final class HttpExistence
         String oldName = Thread.currentThread().getName();
 
         request = new HttpHead( url );
+
+        addFieldToActiveSpan( "http-target", url );
+        addFieldToActiveSpan( "activity", "httpclient-existence" );
 
         try
         {

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpListing.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpListing.java
@@ -16,6 +16,8 @@
 package org.commonjava.maven.galley.transport.htcli.internal;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
+import static org.commonjava.o11yphant.trace.TraceManager.addFieldToActiveSpan;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -64,6 +66,9 @@ public class HttpListing
     public ListingResult call()
     {
         request = new HttpGet( url );
+
+        addFieldToActiveSpan( "http-target", url );
+        addFieldToActiveSpan( "activity", "httpclient-listing" );
 
         // return null if something goes wrong, after setting the error.
         // What we should be doing here is trying to retrieve the html directory

--- a/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpPublish.java
+++ b/transports/httpclient/src/main/java/org/commonjava/maven/galley/transport/htcli/internal/HttpPublish.java
@@ -27,6 +27,8 @@ import org.commonjava.maven.galley.transport.htcli.Http;
 import org.commonjava.maven.galley.transport.htcli.model.HttpLocation;
 import org.commonjava.maven.galley.util.ContentTypeUtils;
 
+import static org.commonjava.o11yphant.trace.TraceManager.addFieldToActiveSpan;
+
 public final class HttpPublish
     extends AbstractHttpJob
     implements PublishJob
@@ -54,6 +56,10 @@ public final class HttpPublish
     {
         //            logger.info( "Trying: {}", url );
         final HttpPut put = new HttpPut( url );
+
+        addFieldToActiveSpan( "http-target", url );
+        addFieldToActiveSpan( "activity", "httpclient-publish" );
+
         put.setEntity( new InputStreamEntity( stream, length, ContentType.create( contentType ) ) );
 
         request = put;


### PR DESCRIPTION
This will use the new jhttpc helper to inject client traces whenever files are downloaded, uploaded, listed, checked for existence, etc.