### PR TITLE
Delete empty dir quietly during listing

### DIFF
--- a/core/src/main/java/org/commonjava/maven/galley/internal/TransferManagerImpl.java
+++ b/core/src/main/java/org/commonjava/maven/galley/internal/TransferManagerImpl.java
@@ -316,7 +316,7 @@ public class TransferManagerImpl
                                     {
                                         // if the directory is there but it's empty, we should delete it
                                         logger.info( "Delete empty folder, {}", childRef.getFullPath() );
-                                        forceDelete( childRef );
+                                        deleteQuietly( childRef );
                                     }
                                     else
                                     {
@@ -410,6 +410,18 @@ public class TransferManagerImpl
         logger.debug( "Final listing result:\n\n{}\n\n", resultingNames );
 
         return new ListingResult( resource, resultingNames.toArray( new String[0] ) );
+    }
+
+    private void deleteQuietly( Transfer childRef )
+    {
+        try
+        {
+            forceDelete(childRef);
+        }
+        catch ( IOException e )
+        {
+            logger.warn( "Delete failed, childRef: " + childRef, e );
+        }
     }
 
     private void forceDelete( Transfer childRef ) throws IOException


### PR DESCRIPTION
Sometimes after rollback a promotion, there is an empty dir left. But galley failed to delete it during the listing (in order to re-create the meta).
This is because nfs left a weird .nfsxxxx file there. After a while, it will be gone. We can just ignore such error during the listing.