### PR TITLE
Checking the timeout before returning transfer

### DIFF
--- a/caches/path-mapped/pom.xml
+++ b/caches/path-mapped/pom.xml
@@ -67,6 +67,10 @@
             <artifactId>cassandra-unit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.commonjava.maven.galley</groupId>
+            <artifactId>galley-core</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
@@ -66,7 +66,8 @@ public class PathMappedCacheProvider
     {
         this.fileEventManager = fileEventManager;
         this.transferDecorator = transferDecorator;
-        this.config = new PathMappedCacheProviderConfig( cacheBasedir );
+        this.config = new PathMappedCacheProviderConfig( cacheBasedir )
+                .withTimeoutProcessingEnabled( Boolean.TRUE );
         this.deleteExecutor = deleteExecutor == null ?
                         newFixedThreadPool( DEFAULT_DELETE_EXECUTOR_POOL_SIZE ) :
                         deleteExecutor;

--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
@@ -15,6 +15,9 @@
  */
 package org.commonjava.maven.galley.cache.pathmapped;
 
+import org.commonjava.maven.galley.io.SpecialPathConstants;
+import org.commonjava.maven.galley.model.SpecialPathInfo;
+import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.commonjava.maven.galley.util.PathUtils;
 import org.commonjava.storage.pathmapped.core.PathMappedFileManager;
 import org.commonjava.maven.galley.io.TransferDecoratorManager;
@@ -33,6 +36,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -55,6 +59,8 @@ public class PathMappedCacheProvider
 
     private PathGenerator pathGenerator;
 
+    private SpecialPathManager specialPathManager;
+
     private static final int DEFAULT_DELETE_EXECUTOR_POOL_SIZE = 2;
 
     public PathMappedCacheProvider( final File cacheBasedir,
@@ -62,7 +68,8 @@ public class PathMappedCacheProvider
                                     final TransferDecoratorManager transferDecorator,
                                     final ExecutorService deleteExecutor,
                                     final PathMappedFileManager fileManager,
-                                    final PathGenerator pathGenerator)
+                                    final PathGenerator pathGenerator,
+                                    final SpecialPathManager specialPathManager)
     {
         this.fileEventManager = fileEventManager;
         this.transferDecorator = transferDecorator;
@@ -73,6 +80,7 @@ public class PathMappedCacheProvider
                         deleteExecutor;
         this.fileManager = fileManager;
         this.pathGenerator = pathGenerator;
+        this.specialPathManager = specialPathManager;
         startReportingDaemon();
     }
 
@@ -232,15 +240,12 @@ public class PathMappedCacheProvider
     public Transfer getTransfer( final ConcreteResource resource )
     {
         Transfer txfr = new Transfer( resource, this, fileEventManager, transferDecorator );
-        final int timeoutSeconds = getResourceTimeoutSeconds( resource );
-        if ( !resource.isRoot() && config.isTimeoutProcessingEnabled() && timeoutSeconds > 0 )
+        if ( !resource.isRoot() && config.isTimeoutProcessingEnabled() )
         {
-            deleteExecutor.submit( () -> {
-                if ( isFileTimeout( txfr, timeoutSeconds ) )
-                {
-                    handleResource( resource, ( f, p ) -> fileManager.delete( f, p ), "transferDelete" );
-                }
-            } );
+            if ( isFileTimeout( txfr ) )
+            {
+                handleResource( resource, ( f, p ) -> fileManager.delete( f, p ), "transferDelete" );
+            }
         }
         return txfr;
     }
@@ -252,12 +257,39 @@ public class PathMappedCacheProvider
                                       config.getDefaultTimeoutSeconds() );
     }
 
+    private int getResourceMetadataTimeoutSeconds( final ConcreteResource resource )
+    {
+        return resource.getLocation()
+                .getAttribute( Location.METADATA_TIMEOUT_SECONDS, Integer.class,
+                        config.getDefaultTimeoutSeconds() );
+    }
+
     /**
      * Return true if it is both a file and timeout. False if file not exists or directory. This is because
      * getFileLastModified return -1 when file not exists or directory.
      */
-    private boolean isFileTimeout( final Transfer txfr, int timeoutSeconds )
+    private boolean isFileTimeout( final Transfer txfr )
     {
+        int timeoutSeconds = 0;
+        SpecialPathInfo pathInfo = null;
+
+        for ( String pkgType : Arrays.asList(SpecialPathConstants.PKG_TYPE_MAVEN, SpecialPathConstants.PKG_TYPE_NPM) ) {
+            pathInfo = specialPathManager.getSpecialPathInfo(txfr, pkgType);
+            if ( pathInfo != null && pathInfo.isMetadata() ) {
+                timeoutSeconds = getResourceMetadataTimeoutSeconds(txfr.getResource());
+                break;
+            }
+        }
+        if ( pathInfo == null || !pathInfo.isMetadata() )
+        {
+            timeoutSeconds = getResourceTimeoutSeconds(txfr.getResource());
+        }
+
+        if ( timeoutSeconds <= 0 )
+        {
+            return false;
+        }
+
         final long current = System.currentTimeMillis();
         final long lastModified = txfr.lastModified();
         if ( lastModified <= 0 )

--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderFactory.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderFactory.java
@@ -17,6 +17,8 @@ package org.commonjava.maven.galley.cache.pathmapped;
 
 import org.commonjava.maven.galley.GalleyInitException;
 import org.commonjava.maven.galley.cache.CacheProviderFactory;
+import org.commonjava.maven.galley.io.SpecialPathManagerImpl;
+import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.commonjava.storage.pathmapped.config.PathMappedStorageConfig;
 import org.commonjava.storage.pathmapped.core.FileBasedPhysicalStore;
 import org.commonjava.storage.pathmapped.core.PathMappedFileManager;
@@ -45,6 +47,8 @@ public class PathMappedCacheProviderFactory
     private PathDB pathDB;
 
     private PhysicalStore physicalStore;
+
+    private SpecialPathManager specialPathManager;
 
     public PathMappedCacheProviderFactory( File cacheDir, ExecutorService deleteExecutor,
                                            PathMappedStorageConfig config )
@@ -78,9 +82,13 @@ public class PathMappedCacheProviderFactory
                 {
                     physicalStore = new FileBasedPhysicalStore( cacheDir );
                 }
+                if ( specialPathManager == null )
+                {
+                    specialPathManager = new SpecialPathManagerImpl();
+                }
                 provider = new PathMappedCacheProvider( cacheDir, fileEventManager, transferDecorator, deleteExecutor,
                                                         new PathMappedFileManager( config, pathDB, physicalStore ),
-                                                        pathGenerator );
+                                                        pathGenerator, specialPathManager );
             }
             catch ( Exception ex )
             {

--- a/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderCassandraTest.java
+++ b/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderCassandraTest.java
@@ -19,6 +19,7 @@ import com.datastax.driver.core.Session;
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.commonjava.maven.galley.cache.CacheProviderTCK;
 import org.commonjava.maven.galley.cache.MockPathGenerator;
+import org.commonjava.maven.galley.io.SpecialPathManagerImpl;
 import org.commonjava.storage.pathmapped.config.DefaultPathMappedStorageConfig;
 import org.commonjava.storage.pathmapped.pathdb.datastax.CassandraPathDB;
 import org.commonjava.storage.pathmapped.core.FileBasedPhysicalStore;
@@ -106,7 +107,7 @@ public class PathMappedCacheProviderCassandraTest
                                                  new FileBasedPhysicalStore( baseDir ) );
         provider = new PathMappedCacheProvider( baseDir, events, new TransferDecoratorManager( decorator ),
                                                 Executors.newScheduledThreadPool( 2 ),
-                                                fileManager, pathgen );
+                                                fileManager, pathgen, new SpecialPathManagerImpl());
     }
 
     @After

--- a/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderJPATest.java
+++ b/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderJPATest.java
@@ -17,6 +17,7 @@ package org.commonjava.maven.galley.cache.pathmapped;
 
 import org.commonjava.maven.galley.cache.CacheProviderTCK;
 import org.commonjava.maven.galley.cache.MockPathGenerator;
+import org.commonjava.maven.galley.io.SpecialPathManagerImpl;
 import org.commonjava.storage.pathmapped.config.DefaultPathMappedStorageConfig;
 import org.commonjava.storage.pathmapped.core.FileBasedPhysicalStore;
 import org.commonjava.storage.pathmapped.core.PathMappedFileManager;
@@ -69,7 +70,7 @@ public class PathMappedCacheProviderJPATest
                                                 Executors.newScheduledThreadPool( 2 ),
                                                 new PathMappedFileManager( new DefaultPathMappedStorageConfig(),
                                                                            new JPAPathDB( "test" ),
-                                                                           new FileBasedPhysicalStore( baseDir ) ), pathgen );
+                                                                           new FileBasedPhysicalStore( baseDir ) ), pathgen, new SpecialPathManagerImpl());
     }
 
     @Override


### PR DESCRIPTION
Let's enable this and check if the file is timeout, to avoid to return the stale file. There are 1000+ stale npm package metadata files in devel-master,  and we have to delete one by one without this checker. 