### PR TITLE
Add log for investigation

### DIFF
--- a/core/src/main/java/org/commonjava/maven/galley/internal/xfer/DownloadHandler.java
+++ b/core/src/main/java/org/commonjava/maven/galley/internal/xfer/DownloadHandler.java
@@ -122,6 +122,7 @@ public class DownloadHandler
                 return target;
             }
 
+            logger.debug( "List the pending jobs: {}", pending );
             future = pending.get( target );
             if ( future == null )
             {


### PR DESCRIPTION
I am investigating the issue: MMENG-2392. Where the logs showed that there were duplicated download jobs created when there were two requests for the same package. And I can reproduce it on stage but cannot on local. So adding this log to check the pending jobs to see if that helps. 