### PR TITLE
Fix pathmap cacheprovider timeout issue

### DIFF
--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderConfig.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderConfig.java
@@ -25,7 +25,7 @@ public class PathMappedCacheProviderConfig
 
     private String storageStrategy = DEFAULT_STORAGE_STRATEGY;
 
-    private static final int DEFAULT_TIMEOUT_SECONDS = 86400;
+    private static final int DEFAULT_TIMEOUT_SECONDS = -1; // never timeout
 
     private boolean timeoutProcessingEnabled;
 

--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderFactory.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderFactory.java
@@ -50,14 +50,17 @@ public class PathMappedCacheProviderFactory
 
     private SpecialPathManager specialPathManager;
 
+    private PathMappedCacheProviderConfig cacheProviderConfig;
+
     public PathMappedCacheProviderFactory( File cacheDir, ExecutorService deleteExecutor,
                                            PathMappedStorageConfig config )
     {
-        this( cacheDir, deleteExecutor, config, null, null );
+        this( cacheDir, deleteExecutor, config, null, null, null );
     }
 
     public PathMappedCacheProviderFactory( File cacheDir, ExecutorService deleteExecutor,
-                                           PathMappedStorageConfig config, PathDB pathDB, PhysicalStore physicalStore )
+                                           PathMappedStorageConfig config, PathDB pathDB, PhysicalStore physicalStore,
+                                           PathMappedCacheProviderConfig cacheProviderConfig )
     {
         this.cacheDir = cacheDir;
         this.deleteExecutor = deleteExecutor;
@@ -86,7 +89,11 @@ public class PathMappedCacheProviderFactory
                 {
                     specialPathManager = new SpecialPathManagerImpl();
                 }
-                provider = new PathMappedCacheProvider( cacheDir, fileEventManager, transferDecorator, deleteExecutor,
+                if ( cacheProviderConfig == null )
+                {
+                    cacheProviderConfig = new PathMappedCacheProviderConfig( cacheDir );
+                }
+                provider = new PathMappedCacheProvider( cacheDir, fileEventManager, transferDecorator, cacheProviderConfig, deleteExecutor,
                                                         new PathMappedFileManager( config, pathDB, physicalStore ),
                                                         pathGenerator, specialPathManager );
             }

--- a/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderJPATest.java
+++ b/caches/path-mapped/src/test/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderJPATest.java
@@ -66,7 +66,7 @@ public class PathMappedCacheProviderJPATest
         final PathGenerator pathgen = new MockPathGenerator();
 
         File baseDir = temp.newFolder();
-        provider = new PathMappedCacheProvider( baseDir, events, new TransferDecoratorManager( decorator ),
+        provider = new PathMappedCacheProvider( baseDir, events, new TransferDecoratorManager( decorator ), null,
                                                 Executors.newScheduledThreadPool( 2 ),
                                                 new PathMappedFileManager( new DefaultPathMappedStorageConfig(),
                                                                            new JPAPathDB( "test" ),


### PR DESCRIPTION
The old code use 86400s (24 hours) as the default timeout, and removes any files old than that. This is wrong.
1. "DEFAULT_TIMEOUT_SECONDS = -1". It mean never timeout. 
2. Refactor the provider constructor, remove the hard code config, take the config object as param so Indy can pass one to galley.
I add a test to verify the expiration behavior.