### PR TITLE
Fix isTransferTimeout not working issue

### DIFF
--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderFactory.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProviderFactory.java
@@ -67,6 +67,7 @@ public class PathMappedCacheProviderFactory
         this.config = config;
         this.pathDB = pathDB;
         this.physicalStore = physicalStore;
+        this.cacheProviderConfig = cacheProviderConfig;
     }
 
     @Override


### PR DESCRIPTION
There are two bugs.
A. the Indy's config is not passed to PathMappedCacheProviderFactory properly, so the timeout check is never enabled. 
B. the path use to get special info not work for NPM. e.g, it passes the "/jquery" and the special checks are not aware of it. We need to translate it to "/jquery/package.json". 