### PR TITLE
Add log for removing resource

### DIFF
--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
@@ -247,6 +247,9 @@ public class PathMappedCacheProvider
         {
             if ( isTransferTimeout( txfr ) )
             {
+
+                logger.info("Removing resource {} as timeout.", resource);
+
                 handleResource( resource, ( f, p ) -> fileManager.delete( f, p ), "transferDelete" );
             }
         }


### PR DESCRIPTION
When I debug the issue: MMENG-3066, there is no related `DELETE` operation from outside, I am suspect that we may delete this as timeout, but there is no logs for this. Let's record the delete caused by the timeout, to help to investigate.  