### PR TITLE
Fix the timeout of the metadata resource

### DIFF
--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
@@ -264,7 +264,7 @@ public class PathMappedCacheProvider
     {
         return resource.getLocation()
                 .getAttribute( Location.METADATA_TIMEOUT_SECONDS, Integer.class,
-                        config.getDefaultTimeoutSeconds() );
+                        Location.DEFAULT_CACHE_TIMEOUT_SECONDS );
     }
 
     /**


### PR DESCRIPTION
Try to fix the issue MMENG-3428: "NPM group metadata were not refreshed".  Ref: https://github.com/Commonjava/galley/blob/master/api/src/main/java/org/commonjava/maven/galley/util/LocationUtils.java#L54

the metadata under group should be refreshed regularly but not never timeout.  