### PR TITLE
Fix the checker on expiration

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/io/SpecialPathConstants.java
+++ b/api/src/main/java/org/commonjava/maven/galley/io/SpecialPathConstants.java
@@ -178,8 +178,6 @@ class NPMSpecialPathSet implements SpecialPathSet
 
         npmSpecialPaths.add( SpecialPathInfo.from( new FilePatternMatcher( ".*(\\.md5|\\.sha[\\d]+)$" ) )
                                             .setDecoratable( false )
-                                            .setMergable( true )
-                                            .setMetadata( true )
                                             .build() );
     }
 

--- a/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
+++ b/caches/path-mapped/src/main/java/org/commonjava/maven/galley/cache/pathmapped/PathMappedCacheProvider.java
@@ -240,7 +240,7 @@ public class PathMappedCacheProvider
     public Transfer getTransfer( final ConcreteResource resource )
     {
         Transfer txfr = new Transfer( resource, this, fileEventManager, transferDecorator );
-        if ( !resource.isRoot() && config.isTimeoutProcessingEnabled() )
+        if ( resource.allowsDeletion() && !resource.isRoot() && config.isTimeoutProcessingEnabled() )
         {
             if ( isTransferTimeout( txfr ) )
             {


### PR DESCRIPTION
This includes:

- checksum files should be set `false` on metadata field, keep the NPM setting same with maven setting
- add the checker for resource before deletion, avoid to delete the files from the readonly repo