### PR TITLE
Support 'path+query' base64 encode

### DIFF
--- a/api/src/main/java/org/commonjava/maven/galley/util/LocationUtils.java
+++ b/api/src/main/java/org/commonjava/maven/galley/util/LocationUtils.java
@@ -25,6 +25,10 @@ public final class LocationUtils
 
     private static final Logger logger = LoggerFactory.getLogger( LocationUtils.class );
 
+    public static final String ATTR_PATH_ENCODE = "path-encode";
+
+    public static final String PATH_ENCODE_BASE64 = "base64";
+
     private LocationUtils()
     {
     }

--- a/api/src/test/java/org/commonjava/maven/galley/util/PathUtilsTest.java
+++ b/api/src/test/java/org/commonjava/maven/galley/util/PathUtilsTest.java
@@ -15,14 +15,19 @@
  */
 package org.commonjava.maven.galley.util;
 
+import static org.commonjava.maven.galley.util.LocationUtils.ATTR_PATH_ENCODE;
+import static org.commonjava.maven.galley.util.LocationUtils.PATH_ENCODE_BASE64;
+import static org.commonjava.maven.galley.util.UrlUtils.buildUrl;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.model.SimpleLocation;
 import org.junit.Test;
 
 public class PathUtilsTest
 {
-
     @Test
     public void normalizeDirectoryWithTrailingSlashAndChildFile()
     {
@@ -30,4 +35,20 @@ public class PathUtilsTest
         assertThat( result, equalTo( "dir/child.txt" ) );
     }
 
+    @Test
+    public void buildUrlTest() throws Exception
+    {
+        final String uri = "https://www.somesite.com/";
+        final String expected = uri + "employ?version=1.0";
+
+        // Prepare location with metadata 'path-encode'
+        Location loc = new SimpleLocation( "test", uri );
+        loc.setAttribute(ATTR_PATH_ENCODE, PATH_ENCODE_BASE64);
+
+        // Test resource with base64-encoded virtual path
+        ConcreteResource resource = new ConcreteResource(loc, "L2VtcGxveT92ZXJzaW9uPTEuMA");
+        String url = buildUrl(resource);
+        //System.out.println(url);
+        assertThat( url, equalTo(expected));
+    }
 }


### PR DESCRIPTION
This is part 2 for [MMENG-3880](https://issues.redhat.com/browse/MMENG-3880) - Take query string into account when downloading through generic proxy.
If a Location set the attribute 'path-encode' : 'base64', the buildUrl() will decode the path string by base64 before sending to remote site.
Reason behind: sometimes the remote url comes with query params (?xx-xx) and this style does not match the natural way of caching the file to local storage. In this case, we make such Locations as base64 encoded. The caller encodes the path before sending http request to such Locations.